### PR TITLE
Add a simple language name validation

### DIFF
--- a/ETS2LA/utils/translator.py
+++ b/ETS2LA/utils/translator.py
@@ -34,7 +34,15 @@ def LoadLanguageData():
         
 LoadLanguageData()
 
-LANGUAGE = LANGUAGE_CODES[LANGUAGES.index(settings.Get("global", "language", "English"))]
+try:
+    LANGUAGE = LANGUAGE_CODES[LANGUAGES.index(settings.Get("global", "language", "English"))]
+except ValueError:
+    logging.warning(f"Language '{settings.Get('global', 'language', 'English')}' not found. Falling back to English.")
+    LANGUAGE = LANGUAGE_CODES[LANGUAGES.index("English")]
+    settings.Set("global", "language", "English")
+    settings.Save()
+
+
 SETTINGS_HASH = hashlib.md5(open("ETS2LA/global.json", "rb").read()).hexdigest()
 
 def UpdateFrontendTranslations():
@@ -114,7 +122,13 @@ def CheckForLanguageUpdates():
     cur_hash = hashlib.md5(open("ETS2LA/global.json", "rb").read()).hexdigest()
     if cur_hash != SETTINGS_HASH:
         SETTINGS_HASH = cur_hash
-        LANGUAGE = LANGUAGE_CODES[LANGUAGES.index(settings.Get("global", "language", "English"))]
+        try:
+            LANGUAGE = LANGUAGE_CODES[LANGUAGES.index(settings.Get("global", "language", "English"))]
+        except ValueError:
+            logging.warning(f"Language '{settings.Get('global', 'language', 'English')}' not found. Falling back to English.")
+            LANGUAGE = LANGUAGE_CODES[LANGUAGES.index("English")]
+            settings.Set("global", "language", "English")
+            settings.Save()
         LoadLanguageData()
         UpdateFrontendTranslations()
         UpdateSettingsUITranslations()


### PR DESCRIPTION
now it will automatically set back to English if the "language" in the global.json didnt match the language in the Translations folder