### PR TITLE
Small update. Change the Settings-Map-Navigation options

### DIFF
--- a/Plugins/Map/data.py
+++ b/Plugins/Map/data.py
@@ -100,7 +100,7 @@ load_distance = settings.Get("Map", "LoadDistance", 500)
 """The radius around the truck in meters that should be loaded."""
 use_navigation = settings.Get("Map", "UseNavigation", True)
 """Whether we should drive along the navigation path or just use the basic route planner."""
-auto_accept_threshold = settings.Get("Map", "AutoAcceptThreshold", 10)
+auto_accept_threshold = settings.Get("Map", "AutoAcceptThreshold", 100)
 """The distance in meters from the destination where the truck will automatically accept the current navigation plan."""
 auto_deny_threshold = settings.Get("Map", "AutoDenyThreshold", 100)
 """The distance in meters from the destination where the truck will automatically deny the current navigation plan."""

--- a/Plugins/Map/main.py
+++ b/Plugins/Map/main.py
@@ -55,7 +55,7 @@ class SettingsMenu(ETS2LASettingsMenu):
                     settings.Set("Map", "RoutingMode", routing_mode)
                 Selector("Routing Mode", "RoutingMode", routing_mode, ["shortest", "smallRoads"],
                         description="Choose between fastest routes (shortest) or scenic routes avoiding highways (smallRoads)")
-                Slider("Auto accept threshold", "AutoAcceptThreshold", 20, 0, 100, 1, description="Automatically accept the route when the distance from the destination is below this value.", suffix="m")
+                Slider("Auto accept threshold", "AutoAcceptThreshold", 100, 0, 200, 1, description="Automatically accept the route when the distance from the destination is below this value.", suffix="m")
                 Slider("Auto deny threshold", "AutoDenyThreshold", 100, 0, 1000, 10, description="Automatically deny the route when the distance from the destination is above this value.", suffix="m")
             with Tab("Debug Data"):
                 with EnabledLock():


### PR DESCRIPTION
Change the maximum value of `Auto accept threshold` to `200`
Change the default value of `Auto accept threshold` to `100`
, to make it consistent with the default value of `Auto deny threshold`'s `100`.

Change this default config so that users who are just starting to use will not frequently ask questions about the `Cant find route` pop-up window