### PR TITLE
Fix reverse roads permanently

### DIFF
--- a/Plugins/Map/classes.py
+++ b/Plugins/Map/classes.py
@@ -1061,10 +1061,6 @@ class Road(BaseItem):
     
             start_pos = (start_node.x, start_node.z, start_node.y)
             end_pos = (end_node.x, end_node.z, end_node.y)
-            if "Road 2 plus 1 temp" in self.road_look.name or "Road 1 plus 2 temp" in self.road_look.name:
-                temp_pos = start_pos
-                start_pos = [start_pos[0], end_pos[1], start_pos[2]]
-                end_pos = [end_pos[0], temp_pos[1], end_pos[2]]
 
             start_quaternion = start_node.rotationQuat if hasattr(start_node, 'rotationQuat') else (0, 0, 0, 0)
             end_quaternion = end_node.rotationQuat if hasattr(end_node, 'rotationQuat') else (0, 0, 0, 0)

--- a/Plugins/Map/route/driving.py
+++ b/Plugins/Map/route/driving.py
@@ -29,7 +29,7 @@ def CheckForLaneChange():
         side = lanes[current_index].side
         
         target_index = current_index
-        change = -1 if data.truck_indicating_right else 1
+        change = 1 if data.truck_indicating_right else -1
         
         end_node = data.route_plan[0].end_node
         end_node_in_front = math_helpers.IsInFront([end_node.x, end_node.y], data.truck_rotation, [data.truck_x, data.truck_z])

--- a/Plugins/Map/route/planning.py
+++ b/Plugins/Map/route/planning.py
@@ -643,8 +643,8 @@ def CheckForLaneChangeManual():
         side = lanes[current_index].side
         
         target_index = current_index
-        change = -1 if data.truck_indicating_right else 1
-        
+        change = 1 if data.truck_indicating_right else -1
+
         end_node = data.route_plan[0].end_node
         end_node_in_front = math_helpers.IsInFront([end_node.x, end_node.y], data.truck_rotation, [data.truck_x, data.truck_z])
             
@@ -730,9 +730,9 @@ def CheckForLaneChange():
                 
         end_node_in_front = math_helpers.IsInFront((current.end_node.x, current.end_node.z), data.truck_rotation, (data.truck_x, data.truck_z))
         if end_node_in_front:
-            indicate_side = "left" if target > current_index else "right"
-        else:
             indicate_side = "right" if target > current_index else "left"
+        else:
+            indicate_side = "left" if target > current_index else "right"
             
         if target != current_index:
             planned = current.get_planned_lane_change_distance()

--- a/Plugins/Map/route/planning.py
+++ b/Plugins/Map/route/planning.py
@@ -81,40 +81,11 @@ def RoadToRouteSection(road: c.Road, lane_index: int, invert: bool = False) -> r
     return route_section
                 
 def GetClosestRouteSection() -> rc.RouteSection:
-    in_bounding_box = []
     items: list[c.Prefab | c.Road] = []
     items += data.current_sector_prefabs
     items += data.current_sector_roads
-    for item in items:
-        if item.bounding_box.is_in(c.Position(data.truck_x, data.truck_y, data.truck_z)):
-            in_bounding_box.append(item)
-            
-    closest_lane_id = 0
-    closest_item = None
-    closest_point_distance = math.inf
-    for item in in_bounding_box:
-        if type(item) == c.Prefab:
-            for lane_id, lane in enumerate(item.nav_routes):
-                for point in lane.points:
-                    point_tuple = point.tuple()
-                    point_tuple = (point_tuple[0], point_tuple[2])
-                    distance = math_helpers.DistanceBetweenPoints((data.truck_x, data.truck_z), point_tuple)
-                    if distance < closest_point_distance:
-                        closest_point_distance = distance
-                        closest_item = item
-                        closest_lane_id = lane_id
-                        
-        elif type(item) == c.Road:
-            for lane_id, lane in enumerate(item.lanes):
-                for point in lane.points:
-                    point_tuple = point.tuple()
-                    point_tuple = (point_tuple[0], point_tuple[2])
-                    distance = math_helpers.DistanceBetweenPoints((data.truck_x, data.truck_z), point_tuple)
-                    if distance < closest_point_distance:
-                        closest_point_distance = distance
-                        closest_item = item
-                        closest_lane_id = lane_id
 
+    closest_item, closest_lane_id = get_closest_route_item(items)
     if closest_item == None:
         return None
     
@@ -645,8 +616,8 @@ def CheckForLaneChangeManual():
         target_index = current_index
         change = 1 if data.truck_indicating_right else -1
 
-        end_node = data.route_plan[0].end_node
-        end_node_in_front = math_helpers.IsInFront([end_node.x, end_node.y], data.truck_rotation, [data.truck_x, data.truck_z])
+        closest_item, closest_lane = get_closest_route_item(data.route_plan[0].items)
+        end_node_in_front = math_helpers.IsInFront((closest_item.end_node.x, closest_item.end_node.y), data.truck_rotation, (data.truck_x, data.truck_z))
             
         if side == "left":    
             if end_node_in_front: # Normal lane change
@@ -727,8 +698,9 @@ def CheckForLaneChange():
                 
         if target > len(lanes) - 1:
             target = len(lanes) - 1
-                
-        end_node_in_front = math_helpers.IsInFront((current.end_node.x, current.end_node.z), data.truck_rotation, (data.truck_x, data.truck_z))
+
+        closest_item, closest_lane = get_closest_route_item(current.items)
+        end_node_in_front = math_helpers.IsInFront((closest_item.end_node.x, closest_item.end_node.y), data.truck_rotation, (data.truck_x, data.truck_z))
         if end_node_in_front:
             indicate_side = "right" if target > current_index else "left"
         else:
@@ -821,3 +793,40 @@ def UpdateRoutePlan():
             CheckForLaneChange()
         except:
             pass
+
+def get_closest_route_item(items: list[c.Prefab | c.Road] | list[rc.RouteItem]):
+    in_bounding_box = []
+    for item in items:
+        if isinstance(item, rc.RouteItem):
+            item = item.item
+
+        if item.bounding_box.is_in(c.Position(data.truck_x, data.truck_y, data.truck_z)):
+            in_bounding_box.append(item)
+
+    closest_lane_id = 0
+    closest_item = None
+    closest_point_distance = math.inf
+    for item in in_bounding_box:
+        if type(item) == c.Prefab:
+            for lane_id, lane in enumerate(item.nav_routes):
+                for point in lane.points:
+                    point_tuple = point.tuple()
+                    point_tuple = (point_tuple[0], point_tuple[2])
+                    distance = math_helpers.DistanceBetweenPoints((data.truck_x, data.truck_z), point_tuple)
+                    if distance < closest_point_distance:
+                        closest_point_distance = distance
+                        closest_item = item
+                        closest_lane_id = lane_id
+
+        elif type(item) == c.Road:
+            for lane_id, lane in enumerate(item.lanes):
+                for point in lane.points:
+                    point_tuple = point.tuple()
+                    point_tuple = (point_tuple[0], point_tuple[2])
+                    distance = math_helpers.DistanceBetweenPoints((data.truck_x, data.truck_z), point_tuple)
+                    if distance < closest_point_distance:
+                        closest_point_distance = distance
+                        closest_item = item
+                        closest_lane_id = lane_id
+
+    return closest_item, closest_lane_id

--- a/Plugins/Map/utils/road_helpers.py
+++ b/Plugins/Map/utils/road_helpers.py
@@ -58,9 +58,6 @@ def calculate_lanes(points, lane_width, num_left_lanes, num_right_lanes, road, c
 
         base_custom_offset = custom_offset
 
-        if (num_left_lanes == 2 and num_right_lanes == 1) or (num_left_lanes == 1 and num_right_lanes == 2):
-            points = points[::-1]
-
         pointCount = len(points)
         for i in range(pointCount - 1):
             point1 = points[i].list()
@@ -110,8 +107,8 @@ def calculate_lanes(points, lane_width, num_left_lanes, num_right_lanes, road, c
                 else:
                     offset = perp_vector * (lane_width * (lane) + custom_offset / 2)
 
-                left_point1 = point1 + offset
-                left_point2 = point2 + offset
+                left_point1 = point1 - offset
+                left_point2 = point2 - offset
                 lanes['left'][lane].append(left_point1.tolist())
                 if i == len(points) - 2:
                     lanes['left'][lane].append(left_point2.tolist())
@@ -121,8 +118,8 @@ def calculate_lanes(points, lane_width, num_left_lanes, num_right_lanes, road, c
                     offset = perp_vector * (lane_width * (lane + 1))
                 else:
                     offset = perp_vector * (lane_width * (lane) + custom_offset / 2)
-                right_point1 = point1 - offset
-                right_point2 = point2 - offset
+                right_point1 = point1 + offset
+                right_point2 = point2 + offset
                 lanes['right'][lane].append(right_point1.tolist())
                 if i == len(points) - 2:
                     lanes['right'][lane].append(right_point2.tolist())


### PR DESCRIPTION
### Fix reverse roads:
Just reverse the offset calculation and roads with "2 plus 1", "1 plus 2" etc will no longer opposite.
There is also a PR made to visualization.

### Fix truck direction check:
![image](https://github.com/user-attachments/assets/756898b0-5cba-446e-b1f8-14765c8cd805)
As picture above, the original function will be wrong at this situation.
