### PR TITLE
Hotfix(TTS): correct route distance unit

### DIFF
--- a/Plugins/TTS/main.py
+++ b/Plugins/TTS/main.py
@@ -339,7 +339,7 @@ class Plugin(ETS2LAPlugin):
             for distance in self.notified_distances:
                 if route_distance <= distance and distance not in self.notified_markers:
                     if self.last_route_distance > 0 and route_distance < self.last_route_distance:
-                        self.speak(Translate("tts.route.distance", [distance]))
+                        self.speak(Translate("tts.route.distance", [distance / 1000]))
                         self.notified_markers.add(distance)
             
             if route_distance > self.last_route_distance + 50:


### PR DESCRIPTION
Correct route distance unit:
| original | fixed | real |
| -------- | ----- | ----- |
| 100km | 1km | 1km (left) |

TTS will now alert you when you are [2, 5, 10, 20, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1500, 2000, 2500, 3000] **METERS** to the next waypoint.
