### PR TITLE
Refactor Update Check Workflow & Update pywin32 Version to 311

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ beautifulsoup4
 pywebview==5.1
 opencv-python
 numpy==2.2.6
-pywin32==306
+pywin32==311
 torchvision
 sounddevice
 matplotlib


### PR DESCRIPTION
# Refactor Update Check Workflow & Update pywin32 to Version 311

---

### Issue

1. **Support Python 3.13**  
   The current `pywin32` version 306 cannot be imported under Python 3.13.

2. **Fetch Timeout Problem**  
   In certain network environments, the `git fetch` operation runs very slowly and frequently exceeds the default 4-second timeout.
   ```cmd
   [WRN] 22:33:06  Unable to fetch origin: Cmd('git') failed due to: exit code(1)                           version.py:50
                  cmdline: git fetch -v -- origin
                  stderr: 'error: process killed because it timed out. kill_after_timeout=4 seconds'
                Update check will be skipped.
   [WRN] 22:34:04  Unable to fetch origin: Cmd('git') failed due to: exit code(128)                         version.py:50
                  cmdline: git fetch -v -- origin
                  stderr: 'error: process killed because it timed out. kill_after_timeout=4 seconds'
                Update check will be skipped.
   ```

### Changes Summary

1. Updated `pywin32` version from 306 to 311.
2. **Refactored the version update check workflow for ETS2LA**:  
   - Replaced `git fetch` with `git ls-remote` to reduce resource usage and improve reliability during update checks.

---

### Notes  
This change has not been tested in production environment. Modifications to the repository are required to generate a new hash for testing purposes.

Submitted by: **Maicarons**