### PR TITLE
fix: add prefab_description check in build_nav_routes

### DIFF
--- a/Plugins/Map/classes.py
+++ b/Plugins/Map/classes.py
@@ -2682,6 +2682,8 @@ class Prefab(BaseItem):
 
     def build_nav_routes(self):
         self._nav_routes = []
+        if self.prefab_description is None:
+            return
         for route in self.prefab_description.nav_routes:
             self._nav_routes.append(
                 PrefabNavRoute(


### PR DESCRIPTION
Adds a null check to prevent AttributeError when prefab_description is None during prefab navigation route generation.