### PR TITLE
Implement changes according to new TruckLib version.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -42,4 +42,4 @@ jobs:
           vpk pack -u ETS2LA.ETS2LA -v ${{ steps.get-version.outputs.version }} -p publish
 
           # Upload as pre-release for now
-          vpk upload github --channel "win-beta" --pre --merge --repoUrl https://github.com/${{ github.repository }} --publish --releaseName "ETS2LA C# v${{ steps.get-version.outputs.version }}" --tag v${{ steps.get-version.outputs.version }} --token ${{ secrets.GITHUB_TOKEN }}
+          vpk upload github --channel "win-beta" --pre --merge --repoUrl https://github.com/${{ github.repository }} --publish --releaseName "ETS2LA C# v${{ steps.get-version.outputs.version }}" --tag v${{ steps.get-version.outputs.version }} --token ${{ secrets.GITHUB_TOKEN }} --targetCommitish ${{ github.sha }}

--- a/ETS2LA.Game/ETS2LA.Game.csproj
+++ b/ETS2LA.Game/ETS2LA.Game.csproj
@@ -12,8 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="TruckLib" Version="0.3.1" />
-    <PackageReference Include="TruckLib.HashFs" Version="0.2.2" />
+    <PackageReference Include="TruckLib" Version="0.3.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
   </ItemGroup>

--- a/Plugins/ExampleConsumer/Program.cs
+++ b/Plugins/ExampleConsumer/Program.cs
@@ -24,7 +24,7 @@ namespace ExampleConsumer
             _bus?.Subscribe<TrafficData>("ETS2LASDK.Traffic", OnTrafficReceived);
             _bus?.Subscribe<SemaphoreData>("ETS2LASDK.Semaphores", OnSemaphoreReceived);
             _bus?.Subscribe<NavigationData>("ETS2LASDK.Navigation", OnNavigationReceived);
-            Logger.Info($"ExampleConsumer read {GameHandler.Instance.Installations[0].GetMap().Nodes.Count} nodes from the game map.");
+            Logger.Info($"ExampleConsumer read {GameHandler.Instance.Installations[0].GetMapData().Nodes.Count} nodes from the game map.");
         }
 
         public override void OnDisable()


### PR DESCRIPTION
- Ignore item types we don't need. RAM from 8gb to 2.4gb.
- Show parsing progress.
- Correct `targetCommitish` value for the rewrite branch.