### PR TITLE
security: harden local services, settings persistence, and plugin installs

### DIFF
--- a/ETS2LA/Networking/Servers/notifications.py
+++ b/ETS2LA/Networking/Servers/notifications.py
@@ -38,6 +38,7 @@ dialog (open dialog):
 
 from ETS2LA.Utils.translator import _
 from ETS2LA.Handlers import sounds
+from ETS2LA.Settings import GlobalSettings
 
 from typing import Literal
 import logging
@@ -59,6 +60,8 @@ Connected websockets and their messages.
 
 condition = threading.Condition()
 """Threading condition to wait for a response"""
+
+settings = GlobalSettings()
 
 
 async def server(websocket, path) -> None:
@@ -240,8 +243,9 @@ def dialog(ui: dict, no_response: bool = False) -> dict | None:
 
 
 async def start() -> None:
-    """Serve the websocket server on 0.0.0.0 and port 37521."""
-    wsServer = websockets.serve(server, "0.0.0.0", 37521, logger=logging.Logger("null"))
+    """Serve the websocket server on the configured bind host and port 37521."""
+    host = "0.0.0.0" if settings.expose_websockets_to_lan else "127.0.0.1"
+    wsServer = websockets.serve(server, host, 37521, logger=logging.Logger("null"))
     await wsServer
 
 

--- a/ETS2LA/Networking/Servers/pages.py
+++ b/ETS2LA/Networking/Servers/pages.py
@@ -8,6 +8,7 @@ from ETS2LA.Handlers.pages import (
 )
 import ETS2LA.Handlers.plugins as plugins
 import ETS2LA.variables as variables
+from ETS2LA.Settings import GlobalSettings
 from typing import Dict
 import websockets
 import threading
@@ -17,6 +18,7 @@ import json
 import time
 
 connected: Dict[websockets.WebSocketServerProtocol, list[str]] = {}
+settings = GlobalSettings()
 """
 {
     websocket: [url1, url2, ...]
@@ -170,7 +172,8 @@ async def update_loop():
 
 # Start server + updater loop
 async def start():
-    server = websockets.serve(handler, "0.0.0.0", 37523)
+    host = "0.0.0.0" if settings.expose_websockets_to_lan else "127.0.0.1"
+    server = websockets.serve(handler, host, 37523)
     await server
     await update_loop()
 

--- a/ETS2LA/Networking/Servers/webserver.py
+++ b/ETS2LA/Networking/Servers/webserver.py
@@ -29,7 +29,7 @@ import ETS2LA.Utils.version as git
 
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
-from fastapi import FastAPI, Body
+from fastapi import FastAPI, Body, HTTPException, Request
 from typing import Literal
 from typing import Any
 import multiprocessing
@@ -52,6 +52,31 @@ settings = GlobalSettings()
 IP = None
 
 FRONTEND_PORT = settings.frontend_port
+
+
+def _is_loopback_client(request: Request) -> bool:
+    host = request.client.host if request.client else ""
+    return host in {"127.0.0.1", "::1", "localhost"}
+
+
+def _require_local_or_token(request: Request, *, sensitive: bool = True) -> None:
+    if _is_loopback_client(request):
+        return
+
+    if not settings.expose_backend_to_lan:
+        raise HTTPException(
+            status_code=403,
+            detail="Backend access is restricted to localhost by default.",
+        )
+
+    if sensitive and settings.backend_api_token:
+        provided = request.headers.get("X-ETS2LA-Token") or request.query_params.get(
+            "token"
+        )
+        if provided != settings.backend_api_token:
+            raise HTTPException(
+                status_code=401, detail="Missing or invalid backend API token."
+            )
 
 app = FastAPI(
     title="ETS2LA", description="Backend API for the ETS2LA app.", version="1.0.0"
@@ -93,19 +118,22 @@ def login(code):
 
 
 @app.get("/backend/quit")
-def quitApp():
+def quitApp(request: Request):
+    _require_local_or_token(request)
     variables.CLOSE = True
     return {"status": "ok"}
 
 
 @app.get("/backend/restart")
-def restartApp():
+def restartApp(request: Request):
+    _require_local_or_token(request)
     variables.RESTART = True
     return {"status": "ok"}
 
 
 @app.get("/window/minimize")
-def minimizeApp():
+def minimizeApp(request: Request):
+    _require_local_or_token(request)
     variables.MINIMIZE = True
     return {"status": "ok"}
 
@@ -122,7 +150,8 @@ def update():
 
 
 @app.get("/api/sounds/play/{sound}")
-def play_sound(sound: str):
+def play_sound(sound: str, request: Request):
+    _require_local_or_token(request)
     sounds.Play(sound)
     return True
 
@@ -133,7 +162,8 @@ def get_git_history():
 
 
 @app.get("/api/ui/theme/{theme}")
-def set_theme(theme: Literal["light", "dark"]):
+def set_theme(theme: Literal["light", "dark"], request: Request):
+    _require_local_or_token(request)
     try:
         color_title_bar(theme)
         return True
@@ -176,13 +206,15 @@ def get_stay_on_top():
 
 
 @app.get("/window/stay_on_top/{state}")
-def stay_on_top(state: bool):
+def stay_on_top(state: bool, request: Request):
+    _require_local_or_token(request)
     newState = set_on_top(state)
     return newState
 
 
 @app.get("/window/transparency/{state}")
-def set_transparency_to(state: bool):
+def set_transparency_to(state: bool, request: Request):
+    _require_local_or_token(request)
     try:
         newState = set_transparency(state)
         return newState
@@ -197,7 +229,8 @@ def get_transparency_state():
 
 
 @app.get("/window/fullscreen")
-def toggle_fullscreen_from_ui():
+def toggle_fullscreen_from_ui(request: Request):
+    _require_local_or_token(request)
     return toggle_fullscreen()
 
 
@@ -266,12 +299,14 @@ def get_plugins():
 
 
 @app.get("/backend/plugins/{plugin}/enable")
-def enable_plugin(plugin: str):
+def enable_plugin(plugin: str, request: Request):
+    _require_local_or_token(request)
     return plugins.start_plugin(name=plugin)
 
 
 @app.get("/backend/plugins/{plugin}/disable")
-def disable_plugin(plugin: str):
+def disable_plugin(plugin: str, request: Request):
+    _require_local_or_token(request)
     return plugins.stop_plugin(name=plugin)
 
 
@@ -297,7 +332,8 @@ def get_language():
 # endregion
 # region Popups
 @app.post("/api/popup")
-def popup(data: PopupData):
+def popup(data: PopupData, request: Request):
+    _require_local_or_token(request)
     mainThreadQueue.append(
         [
             sonner,
@@ -317,7 +353,10 @@ def popup(data: PopupData):
 
 
 @app.post("/backend/plugins/{plugin}/settings/{key}/set")
-def set_plugin_setting(plugin: str, key: str, value: Any = Body(...)):  # noqa
+def set_plugin_setting(
+    plugin: str, key: str, request: Request, value: Any = Body(...)
+):  # noqa
+    _require_local_or_token(request)
     if plugin == "global":
         settings.__setattr__(key, value["value"])
         return True
@@ -357,7 +396,8 @@ def get_plugin_settings(plugin: str):
 
 
 @app.post("/api/controls/{control}/change")
-def change_control(control: str):
+def change_control(control: str, request: Request):
+    _require_local_or_token(request)
     mainThreadQueue.append([controls.edit_event, [control], {}])
     while [controls.edit_event, [control], {}] in mainThreadQueue:
         time.sleep(0.01)
@@ -366,7 +406,8 @@ def change_control(control: str):
 
 
 @app.post("/api/controls/{control}/unbind")
-def unbind_control(control: str):
+def unbind_control(control: str, request: Request):
+    _require_local_or_token(request)
     mainThreadQueue.append([controls.unbind_event, [control], {}])
     while [controls.unbind_event, [control], {}] in mainThreadQueue:
         time.sleep(0.01)
@@ -460,7 +501,8 @@ def get_list_of_pages():
 
 
 @app.get("/api/plugins/reload")
-def reload_plugins():
+def reload_plugins(request: Request):
+    _require_local_or_token(request)
     try:
         plugins.reload_plugins()
     except Exception:
@@ -508,7 +550,7 @@ def run():
     global thread
 
     ExtractIP()
-    hostname = "0.0.0.0"
+    hostname = "0.0.0.0" if settings.expose_backend_to_lan else "127.0.0.1"
 
     thread = threading.Thread(
         target=uvicorn.run,

--- a/ETS2LA/Settings/backend.py
+++ b/ETS2LA/Settings/backend.py
@@ -38,6 +38,10 @@ class GlobalSettings(ETS2LASettings):
     advanced_plugin_mode: bool = False
     slow_loading: bool = False
     high_priority: bool = True
+    expose_backend_to_lan: bool = False
+    expose_websockets_to_lan: bool = False
+    backend_api_token: str = ""
+    allow_unsafe_plugin_requirements: bool = False
 
     # Sounds
     soundpack: str = "default"

--- a/ETS2LA/Settings/classes.py
+++ b/ETS2LA/Settings/classes.py
@@ -15,11 +15,13 @@ settings.some_text # "Great!"
 ```
 """
 
-import threading
+import json
 import sqlite3
-import pickle
+import threading
+from typing import Any
 
 root_path = "ETS2LA/settings.db"
+_JSON_PREFIX = "json:"
 
 
 def _init_db():
@@ -38,8 +40,6 @@ def _init_db():
     conn.close()
 
 
-# This is called for each module as it makes sure the settings
-# file exists before anything else is done.
 _init_db()
 
 
@@ -52,7 +52,6 @@ class ETS2LASettings:
         self._cache = {}
         self._lock = threading.RLock()
 
-        # Load defaults (python syntax is so nice...)
         for key, _typ in getattr(self.__class__, "__annotations__", {}).items():
             default = getattr(self.__class__, key, None)
             self._cache[key] = default
@@ -63,10 +62,41 @@ class ETS2LASettings:
         return sqlite3.connect(root_path, timeout=0.1, isolation_level=None)
 
     def defer(self, func, args, time):
-        """Try again after time seconds."""
         timer = threading.Timer(time, func, args=args)
         timer.daemon = True
         timer.start()
+
+    def _serialize_value(self, value: Any) -> str:
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, (str, int, float)):
+            return str(value)
+        try:
+            return _JSON_PREFIX + json.dumps(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Unsupported setting value for {self._category}: {type(value).__name__}"
+            ) from exc
+
+    def _deserialize_value(self, raw_value: str, default: Any) -> Any:
+        if raw_value.startswith(_JSON_PREFIX):
+            try:
+                return json.loads(raw_value[len(_JSON_PREFIX) :])
+            except (TypeError, ValueError):
+                return default
+
+        if raw_value.startswith("b'") or raw_value.startswith('b\"'):
+            return default
+
+        typ = type(default)
+        try:
+            if typ is bool:
+                return raw_value.lower() in ("true", "1", "yes")
+            if default is None:
+                return raw_value
+            return typ(raw_value)
+        except Exception:
+            return raw_value
 
     def _load_from_db(self, i=0):
         try:
@@ -77,28 +107,13 @@ class ETS2LASettings:
                 )
                 for key, value in cur.fetchall():
                     if key in self._cache:
-                        # unpickle if needed
-                        if value.startswith("b'") or value.startswith('b"'):
-                            try:
-                                self._cache[key] = pickle.loads(eval(value))
-                                continue
-                            except Exception:
-                                pass
-
-                        # keep type conversion consistent with default
-                        typ = type(self._cache[key])
-                        try:
-                            if typ is bool:
-                                self._cache[key] = value.lower() in ("true", "1", "yes")
-                            else:
-                                self._cache[key] = typ(value)
-                        except Exception:
-                            self._cache[key] = value
+                        self._cache[key] = self._deserialize_value(
+                            value, self._cache[key]
+                        )
 
         except sqlite3.OperationalError:
-            # db busy, try again later max 5 times
             if i < 5:
-                self.defer(self._load_from_db, [i], 0.1 + 0.05 * i)
+                self.defer(self._load_from_db, [i + 1], 0.1 + 0.05 * i)
 
     def __getattribute__(self, name):
         if name.startswith("_") or name in (
@@ -127,23 +142,15 @@ class ETS2LASettings:
 
         with self._lock:
             self._cache[name] = value
-            # pickle if needed
-            if not isinstance(
-                value,
-                (str, int, float, bool),
-            ):
-                value = pickle.dumps(value)
-
-            # otherwise store the value itself
+            serialized_value = self._serialize_value(value)
             try:
                 with self._get_connection() as conn:
                     conn.execute(
                         "INSERT OR REPLACE INTO settings (category, key, value) VALUES (?, ?, ?)",
-                        (self._category, name, str(value)),
+                        (self._category, name, serialized_value),
                     )
 
             except sqlite3.OperationalError:
-                # db busy, try again later max 5 times
                 if i < 5:
                     self.defer(self.__setattr__, [name, value, i + 1], 0.1 + 0.05 * i)
 

--- a/Pages/catalogue.py
+++ b/Pages/catalogue.py
@@ -21,12 +21,14 @@ import ETS2LA.variables as variables
 from typing import Literal
 import webbrowser
 import threading
+import subprocess
 import requests
 import random
 import shutil
 import time
 import yaml
 import git
+import sys
 import os
 
 settings = GlobalSettings()
@@ -280,9 +282,19 @@ class Page(ETS2LAPage):
             if os.path.exists(f"CataloguePlugins/{target.name}/requirements.txt"):
                 self.installing_state = _("Installing requirements")
                 self.reset_timer()
-                os.system(
-                    f"pip install -r CataloguePlugins/{target.name}/requirements.txt"
-                )
+                requirements_path = f"CataloguePlugins/{target.name}/requirements.txt"
+                if settings.allow_unsafe_plugin_requirements:
+                    SendPopup(
+                        "Developer mode: installing third-party Python requirements from this plugin. Only use this if you fully trust the repository and its dependencies."
+                    )
+                    subprocess.run(
+                        [sys.executable, "-m", "pip", "install", "-r", requirements_path],
+                        check=True,
+                    )
+                else:
+                    SendPopup(
+                        "This plugin ships a requirements.txt file. ETS2LA no longer auto-installs third-party Python packages from catalogue plugins. Review the plugin source and install dependencies manually only if you fully trust it."
+                    )
 
             self.installing_state = _("Starting plugin background process")
             self.reset_timer()
@@ -658,6 +670,10 @@ class Page(ETS2LAPage):
                     "ETS2LA is not responsible for any issues caused by 3rd party plugins."
                 ),
                 styles.Classname("text-xs text-muted-foreground"),
+            )
+            Text(
+                "Security warning: catalogue plugins are third-party code from external repositories. ETS2LA no longer auto-installs their Python requirements by default. Only proceed if you trust the plugin author and have reviewed the source.",
+                styles.Classname("text-xs text-yellow-500 text-center max-w-lg"),
             )
             with Container(
                 styles.FlexHorizontal() + styles.Gap("10px") + styles.Classname("pt-4")


### PR DESCRIPTION
## Summary
This PR hardens several local attack surfaces in ETS2LA's desktop/backend runtime.

Attribution: JuniperTheDev

## What was found
- **Unsafe settings deserialization** in `ETS2LA/Settings/classes.py` used `eval(value)` and `pickle.loads(...)` on persisted database values.
- **Catalogue plugin installation** in `Pages/catalogue.py` would clone untrusted third-party repositories and then auto-run `pip install -r requirements.txt` by default.
- **Network exposure by default**: the FastAPI backend and websocket servers bound to `0.0.0.0`, exposing local control surfaces to the LAN by default.
- **Backend HTTP hygiene**: several state-changing endpoints (quit/restart/plugin enable-disable/window control/settings writes/etc.) were remotely callable if the backend was reachable.
- **Shell execution remains** in `ETS2LA/Utils/shell.py` and `ETS2LA/Utils/Game/path.py`; I did not broaden this PR into a larger command-execution refactor because that would be riskier without dedicated test coverage.

## What was fixed
### 1) Safe settings serialization/deserialization
- Removed the `eval(...)` + `pickle.loads(...)` path from `ETS2LA/Settings/classes.py`.
- Added JSON-backed persistence for structured values (`list`, `dict`, tuples that are JSON-serializable, etc.) using a `json:` prefix.
- Legacy persisted `b'...'` / `b"..."` payloads now **fail closed** and fall back to defaults instead of being evaluated or unpickled.

### 2) Catalogue plugin requirement auto-install no longer runs by default
- `Pages/catalogue.py` no longer auto-runs third-party `pip install -r requirements.txt` by default.
- Added a stronger warning in the install confirmation UI.
- Added an explicit developer-only setting `allow_unsafe_plugin_requirements` for users who intentionally want the old behavior and understand the risk.
- When that setting is enabled, the code now uses `subprocess.run([...], check=True)` instead of `os.system(...)`.

### 3) Localhost-by-default bind behavior
- Added explicit settings:
  - `expose_backend_to_lan = False`
  - `expose_websockets_to_lan = False`
  - `backend_api_token = ""`
- Updated these services to bind to `127.0.0.1` by default and only use `0.0.0.0` with explicit opt-in:
  - `ETS2LA/Networking/Servers/webserver.py`
  - `ETS2LA/Networking/Servers/pages.py`
  - `ETS2LA/Networking/Servers/notifications.py`

### 4) Sensitive backend endpoints restricted by default
- Added request gating in `ETS2LA/Networking/Servers/webserver.py`.
- Sensitive endpoints are now localhost-only by default.
- If LAN exposure is explicitly enabled, an optional `backend_api_token` can also be enforced via `X-ETS2LA-Token` header or `?token=` query param.
- Endpoints protected in this patch include:
  - app quit / restart / minimize
  - sound playback
  - theme/window state mutations
  - plugin enable / disable / reload
  - popup dispatch
  - global setting writes
  - control rebinding / unbinding

## Verification performed
Focused verification rather than broad integration tests:

1. **Python syntax / importability**
   - Ran `python3 -m compileall ETS2LA Pages`

2. **Unsafe settings deserialization removed**
   - Confirmed `ETS2LA/Settings/classes.py` no longer contains `eval(` or `pickle.loads`.
   - Ran a small script showing:
     - complex values are persisted as `json:...`
     - JSON-backed values round-trip correctly
     - a legacy pickle-style payload in the settings DB now falls back to the default instead of being evaluated/unpickled

3. **Default bind host is localhost**
   - Verified defaults from `GlobalSettings()`:
     - `expose_backend_to_lan = False`
     - `expose_websockets_to_lan = False`
   - Verified server startup code now selects `127.0.0.1` unless those explicit opt-ins are enabled.

4. **Catalogue no longer auto-runs plugin requirements by default**
   - Confirmed the previous unconditional `pip install -r CataloguePlugins/.../requirements.txt` path is gone.
   - Confirmed default behavior is warning-only, with opt-in developer-only execution behind `allow_unsafe_plugin_requirements`.

## Out of scope / remaining risk
- This PR does **not** attempt to make third-party plugins safe in a sandboxed sense. Installing a plugin still means cloning and later running code from a repository the user chose to trust. This patch mitigates the most dangerous automatic dependency-install path and reduces default exposure, but it does not eliminate the general trust model risk of third-party plugins.
- `shell=True` still exists in other utility paths. I left that for a separate, narrower refactor because changing command execution semantics across the app without dedicated test coverage could break frontend/tooling workflows.
