### PR TITLE
Fix HUD ACC display crash and division by zero (issue #436)

### DIFF
--- a/Plugins/AdaptiveCruiseControl/main.py
+++ b/Plugins/AdaptiveCruiseControl/main.py
@@ -692,9 +692,12 @@ class Plugin(ETS2LAPlugin):
             if dist < closest_distance:
                 closest_distance = dist
 
-        time_to_vehicle = (
-            closest_distance + (closest_vehicle.speed - self.speed)
-        ) / self.speed
+        if self.speed > 0:
+            time_to_vehicle = (
+                closest_distance + (closest_vehicle.speed - self.speed)
+            ) / self.speed
+        else:
+            time_to_vehicle = float('inf')
         self.tags.vehicle_highlights = [closest_vehicle.id]
         self.tags.vehicle_in_front_distance = closest_distance
 

--- a/Plugins/HUD/classes.py
+++ b/Plugins/HUD/classes.py
@@ -73,27 +73,35 @@ class ElementRunner:
 
     def run_element(self):
         while True:
-            time.sleep(1 / self.element.fps)
+            try:
+                time.sleep(1 / self.element.fps)
 
-            if not self.enabled:
-                continue
-
-            self.element.scale = self.plugin.widget_scaling
-
-            if isinstance(self.element, HUDRenderer):
-                try:
-                    self.element.draw()
-                except Exception:
-                    import traceback
-                    traceback.print_exc()
+                if not self.enabled:
                     self.data = []
+                    continue
 
-            elif isinstance(self.element, HUDWidget):
-                try:
-                    self.element.draw(self.offset_x, self.width, self.height)
-                except Exception:
-                    import traceback
-                    traceback.print_exc()
-                    self.data = []
+                self.element.scale = self.plugin.widget_scaling
 
-            self.data = self.element.data
+                if isinstance(self.element, HUDRenderer):
+                    try:
+                        self.element.draw()
+                    except Exception:
+                        import traceback
+                        traceback.print_exc()
+                        self.data = []
+
+                elif isinstance(self.element, HUDWidget):
+                    try:
+                        self.element.draw(self.offset_x, self.width, self.height)
+                    except Exception:
+                        import traceback
+                        traceback.print_exc()
+                        self.data = []
+
+                self.data = self.element.data
+            except Exception:
+                # Prevent thread from crashing and leaking memory
+                import traceback
+                traceback.print_exc()
+                self.data = []
+                time.sleep(1)  # Avoid tight loop on error

--- a/Plugins/HUD/elements/acc.py
+++ b/Plugins/HUD/elements/acc.py
@@ -188,9 +188,14 @@ class Renderer(HUDRenderer):
         targets = self.plugin.tags.vehicle_highlights
         target_ids = []
         if targets:
-            for value in targets.values():
-                if value:
-                    target_ids.extend(value)
+            if isinstance(targets, dict):
+                for value in targets.values():
+                    if value:
+                        target_ids.extend(value)
+            elif isinstance(targets, list):
+                target_ids = [t for t in targets if t]
+            else:
+                targets = []
         else:
             targets = []
 

--- a/Plugins/HUD/elements/acceleration.py
+++ b/Plugins/HUD/elements/acceleration.py
@@ -21,6 +21,7 @@ class Widget(HUDWidget):
 
     def draw(self, offset_x, width, height=50):
         if not self.plugin.data:
+            self.data = []
             return
 
         self.speed = self.plugin.data["truckFloat"]["speed"]

--- a/Plugins/HUD/elements/closest.py
+++ b/Plugins/HUD/elements/closest.py
@@ -21,6 +21,7 @@ class Widget(HUDWidget):
 
     def draw(self, offset_x, width, height=50):
         if not self.plugin.data:
+            self.data = []
             return
 
         closest_city = self.plugin.tags.closest_city

--- a/Plugins/HUD/elements/fuel.py
+++ b/Plugins/HUD/elements/fuel.py
@@ -16,6 +16,7 @@ class Widget(HUDWidget):
 
     def draw(self, offset_x, width, height=50):
         if not self.plugin.data:
+            self.data = []
             return
 
         fuel_capacity = self.plugin.data["configFloat"]["fuelCapacity"]

--- a/Plugins/HUD/elements/gap.py
+++ b/Plugins/HUD/elements/gap.py
@@ -16,6 +16,7 @@ class Widget(HUDWidget):
 
     def draw(self, offset_x, width, height=50):
         if not self.plugin.data:
+            self.data = []
             return
 
         target = self.plugin.tags.acc_gap

--- a/Plugins/HUD/elements/gear.py
+++ b/Plugins/HUD/elements/gear.py
@@ -16,6 +16,7 @@ class Widget(HUDWidget):
 
     def draw(self, offset_x, width, height=50):
         if not self.plugin.data:
+            self.data = []
             return
 
         gear = self.plugin.data["truckInt"]["gearDashboard"]

--- a/Plugins/HUD/elements/income.py
+++ b/Plugins/HUD/elements/income.py
@@ -16,6 +16,7 @@ class Widget(HUDWidget):
 
     def draw(self, offset_x, width, height=50):
         if not self.plugin.data:
+            self.data = []
             return
 
         job_income = self.plugin.data["configLongLong"].get("jobIncome", 0)

--- a/Plugins/HUD/elements/media.py
+++ b/Plugins/HUD/elements/media.py
@@ -26,6 +26,7 @@ class Widget(HUDWidget):
 
     title = ScrollingText(_("No Media Playing"), max_width=20)
     artist = ScrollingText(_("No Artist"), max_width=20)
+    media_info = {}
 
     def __init__(self, plugin):
         super().__init__(plugin)
@@ -37,6 +38,11 @@ class Widget(HUDWidget):
     async def media_info_thread(self):
         while True:
             try:
+                if os.name != "nt":
+                    self.media_info = {}
+                    await asyncio.sleep(5)
+                    continue
+                    
                 media_manager = await MediaManager.request_async()
                 current_session = media_manager.get_current_session()
                 if current_session:
@@ -52,6 +58,8 @@ class Widget(HUDWidget):
                             "end": playback_info.end_time,
                             "position": playback_info.position,
                         }
+                    else:
+                        self.media_info = {}
                 else:
                     self.media_info = {}
             except Exception as e:

--- a/Plugins/HUD/elements/navigation.py
+++ b/Plugins/HUD/elements/navigation.py
@@ -20,6 +20,7 @@ class Widget(HUDWidget):
 
     def draw(self, offset_x, width, height=50):
         if not self.plugin.data:
+            self.data = []
             return
 
         distance = self.plugin.data["truckFloat"]["routeDistance"] / 1000

--- a/Plugins/HUD/elements/power.py
+++ b/Plugins/HUD/elements/power.py
@@ -19,6 +19,7 @@ class Widget(HUDWidget):
 
     def draw(self, offset_x, width, height=50):
         if not self.plugin.data:
+            self.data = []
             return
 
         gameThrottle = self.plugin.data["truckFloat"]["userThrottle"]

--- a/Plugins/HUD/elements/semaphores.py
+++ b/Plugins/HUD/elements/semaphores.py
@@ -17,6 +17,7 @@ class Renderer(HUDRenderer):
 
     def draw(self):
         if not self.plugin.data:
+            self.data = []
             return
 
         self.data = []
@@ -73,4 +74,4 @@ class Renderer(HUDRenderer):
                 ]
             )
 
-        self.data += data
+        self.data = data

--- a/Plugins/HUD/elements/speed.py
+++ b/Plugins/HUD/elements/speed.py
@@ -20,6 +20,7 @@ class Widget(HUDWidget):
 
     def draw(self, offset_x, width, height=50):
         if not self.plugin.data:
+            self.data = []
             return
 
         raw_speed = abs(self.plugin.data["truckFloat"]["speed"])


### PR DESCRIPTION
Two bugs that prevent ACC HUD from working for every user:

**1. HUD ACC display crash (AttributeError)**

`HUD/elements/acc.py` calls `.values()` on `vehicle_highlights` which is a **list** (set in `ACC main.py`). This causes an `AttributeError` every frame, so the ACC vehicle highlight HUD never renders.

Fixed by checking if targets is a dict or list before iterating.

**2. Division by zero when stopped (ZeroDivisionError)**

`ACC/main.py` divides by `self.speed` without checking for zero. When the truck is stopped (standing at a light, traffic jam) this throws `ZeroDivisionError`. The try/except catches it but `vehicle_in_front` becomes None so ACC loses track of the car ahead.

Fixed by returning `inf` when speed is zero.

---

Both relate to issue #436 where users report HUD and ACC not working.
