### PR TITLE
fix issues 518 

### DIFF
--- a/ETS2LA/Handlers/pages.py
+++ b/ETS2LA/Handlers/pages.py
@@ -17,17 +17,21 @@ class PageManager:
     def __init__(self):
         self.get_urls()
 
-    @staticmethod
-    def get_page_names() -> List[str]:
-        """Get list of all page module names without extensions."""
-        files = [
-            f
-            for f in os.listdir(PAGES_PATH)
-            if os.path.isfile(os.path.join(PAGES_PATH, f))
-            and f.endswith(".py")
-            and f != "__init__.py"
-        ]
-        return [f[:-3] for f in files]
+    @classmethod
+    def get_page_names(cls) -> List[str]:
+        """Get list of loadable page module names in the same order as URLs."""
+        files = cls.get_files()
+        names = []
+
+        try:
+            for filename in files:
+                page, _ = cls.load_page_module(filename)
+                if page:
+                    names.append(filename[:-3])
+        finally:
+            ...
+
+        return names
 
     @staticmethod
     def get_page_object(target_url: str) -> Optional[Any]:
@@ -35,6 +39,21 @@ class PageManager:
         for page in page_objects.values():
             if page.url == target_url:
                 return page
+        return None
+
+    @classmethod
+    def get_page_name_for_url(cls, target_url: str) -> Optional[str]:
+        """Find page module name by URL."""
+        files = cls.get_files()
+
+        try:
+            for filename in files:
+                page, _ = cls.load_page_module(filename)
+                if page and page.url == target_url:
+                    return filename[:-3]
+        finally:
+            ...
+
         return None
 
     @staticmethod
@@ -192,6 +211,10 @@ def get_page_names():
 
 def get_page_object(target_url: str):
     return PageManager.get_page_object(target_url)
+
+
+def get_page_name_for_url(target_url: str):
+    return PageManager.get_page_name_for_url(target_url)
 
 
 def page_function_call(page_name: str, function_name: str, *args, **kwargs):

--- a/ETS2LA/Networking/Servers/pages.py
+++ b/ETS2LA/Networking/Servers/pages.py
@@ -1,7 +1,7 @@
 from ETS2LA.Handlers.pages import (
     get_page,
     get_urls,
-    get_page_names,
+    get_page_name_for_url,
     page_function_call,
     open_event,
     close_event,
@@ -29,8 +29,9 @@ connected: Dict[websockets.WebSocketServerProtocol, list[str]] = {}
 def send_open_event(url: str):
     page_urls = get_urls()
     if url in page_urls:
-        page_names = get_page_names()
-        name = page_names[page_urls.index(url)]
+        name = get_page_name_for_url(url)
+        if not name:
+            return
         open_event(name)
     else:
         plugins.page_open_event(url)
@@ -41,8 +42,9 @@ def send_open_event(url: str):
 def send_close_event(url: str):
     page_urls = get_urls()
     if url in page_urls:
-        page_names = get_page_names()
-        name = page_names[page_urls.index(url)]
+        name = get_page_name_for_url(url)
+        if not name:
+            return
         close_event(name)
     else:
         plugins.page_close_event(url)
@@ -60,7 +62,6 @@ def render_page(url: str):
 # Handle a function call from the frontend.
 def handle_functions(data: dict):
     page_urls = get_urls()
-    page_names = get_page_names()
 
     url = data.get("url")
     func = data.get("target", "")
@@ -68,7 +69,9 @@ def handle_functions(data: dict):
 
     if url in page_urls:
         try:
-            name = page_names[page_urls.index(url)]
+            name = get_page_name_for_url(url)
+            if not name:
+                return
             if args:
                 page_function_call(name, func.split(".")[-1], *args)
             else:

--- a/__p.py
+++ b/__p.py
@@ -1,0 +1,4 @@
+import sys 
+print(sys.executable) 
+print(sys.path) 
+import ETS2LA 


### PR DESCRIPTION
> [!NOTE] 
>This PR text was translated from Chinese to English using Google Translate.

<!--
# Important warning
Before making a pull request, please note that ETS2LA does not allow agentic tools in our codebase.
This rule does not affect third party plugins, but if you intend to create PRs (Pull Requests) to the main application, you must follow our guidelines on this.
Usually Ask mode is allowed, but please do note that AI code itself is almost entirely banned. Ask is meant for asking, not for coding.

# Description
Please include a quick summary of the changes you've made here. If this PR fixes a specific issue, please link it here.
-->
## Type of change
Check the relavent options (place an "x" between the brackets)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## change declaration

### Handlers

``` bash
ETS2LA/Handlers/pages.py
```

- Unify the filtering rules for the "page name list" and the "loadable URL list" to avoid index misalignment caused by _*.py pages.

1.The `get_page_names` method was changed from `@staticmethod` to `@classmethod`, discarding the original method that retrieved names from `os.listdir`. Instead, `load_page_module` was rewritten to only collect names of "loadable pages".(line21)

2.A new function, `get_page_name_for_url(target_url)`, has been added to directly retrieve the page module name based on the URL.(line45)

3.Add a new module export function get_page_name_for_url(...) for external calls (pages.py:216)

### networking/server

``` bash
ETS2LA/Networking/Servers/pages.py
```

-The button callback for `/onboarding` is dispatched to the `onboarding` page object, fixing the `AttributeError` in `increment_page/handle_skip_onboarding`.

1. Change the import method from `get_page_names` to `get_page_name_for_url` (line:4).

2. Use `get_page_name_for_url(url)` for `send_open_event`, and add `None` protection (line:29). The same applies to `send_close_event` (line:42).

3. Remove `page_names[page_urls.index(url)]` from `handle_functions`, and replace it with direct URL lookup and add protection (line:63).


### __p.py

> [!CAUTION] 
> This section of code is newly created and may affect the overall project.

Print sys.executable and sys.path and test import ETS2LA for environment troubleshooting.

