### PR TITLE
Coerce lookahead_time to float above the vehicle loop

### DIFF
--- a/Plugins/CollisionAvoidance/main.py
+++ b/Plugins/CollisionAvoidance/main.py
@@ -54,11 +54,12 @@ class Plugin(ETS2LAPlugin):
         sensitivity = settings.sensitivity
         intersecting_vehicles = []
         impacts = []
+        lookahead_time = float(settings.lookahead_time)
         for vehicle in vehicles:
             if not IsInFront(vehicle.position.tuple(), truck_rotation, truck_position):
                 continue  # only consider vehicles in front of the truck
 
-            path: list[Position] = vehicle.get_path_for(settings.lookahead_time)
+            path: list[Position] = vehicle.get_path_for(lookahead_time)
             if not path:
                 continue
 


### PR DESCRIPTION
# Description

`CollisionAvoidance.get_intersecting_vehicles` passes `settings.lookahead_time` directly into `Vehicle.get_path_for(...)`. The setting is declared as `float` in `Plugins/CollisionAvoidance/settings.py` (`lookahead_time: float = 3`), but in practice the slider can persist it as a string — I was hitting this with `"2.5"`.

When the stored value is a string, `Traffic/classes.py:get_path_for` does:

```python
for i in range(0, int(seconds * points_per_second)):
```

with `seconds = "2.5"` and `points_per_second = 10`. `"2.5" * 10` is Python string repetition, so the expression becomes `"2.52.52.52.52.52.52.52.52.52.5"`, and `int(...)` raises:

```
ValueError: invalid literal for int() with base 10: '2.52.52.52.52.52.52.52.52.52.5'
```

Plugin crashes, Collision Avoidance stops running until a restart.

The fix is a one-line hoist: coerce to `float` once at the top of `get_intersecting_vehicles`, then pass the local into the loop. When the setting is already numeric, `float(x)` is a no-op. As a side effect we also stop re-doing the attribute lookup + coercion for every tracked vehicle on every tick.

No behaviour change when the setting is numeric.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update