### PR TITLE
Guard data.map access during Map plugin initialization

### DIFF
--- a/Plugins/Map/classes.py
+++ b/Plugins/Map/classes.py
@@ -2742,6 +2742,12 @@ class PrefabNavRoute:
     def generate_points(self, prefab=None) -> list[Position]:
         self.prefab = prefab
 
+        # Short-circuit during Map initialization so we don't do the point
+        # processing below just to discard it — the caching `points` property
+        # only stores non-empty results, so returning [] retries next tick.
+        if isinstance(prefab, Prefab) and (data is None or data.map is None):
+            return []
+
         new_points = []
         for curve in self.curves:
             new_points += curve.points
@@ -2768,8 +2774,6 @@ class PrefabNavRoute:
         self.distance = distance
 
         if isinstance(prefab, Prefab):
-            if data is None or data.map is None:
-                return []  # Map still initializing; empty result triggers retry next tick (self._points stays [])
             start_node = None
             start_distance = math.inf
             end_node = None

--- a/Plugins/Map/classes.py
+++ b/Plugins/Map/classes.py
@@ -2768,6 +2768,8 @@ class PrefabNavRoute:
         self.distance = distance
 
         if isinstance(prefab, Prefab):
+            if data is None or data.map is None:
+                return []  # Map still initializing; empty result triggers retry next tick (self._points stays [])
             start_node = None
             start_distance = math.inf
             end_node = None


### PR DESCRIPTION
# Description

During ETS2LA startup there is a multi-second window where `Plugins/Map/classes.data.map` is still `None`. The setup:

- `Plugins/Map/classes.py:23` declares `data = None` as a module-global placeholder.
- `Plugins/Map/main.py:225` does `c.data = data` — wires the classes module to the data module during Map plugin init.
- `Plugins/Map/main.py:285` does `data.map = data_reader.ReadData(...)` — the long read that loads world data, computes the navigation graph, and calculates sectors.

Between wiring and the map being ready, other plugins polling `prefab.bounding_box` go through the lazy `NavigationRoute.generate_points` path, which at line 2776 hits `data.map.get_node_by_uid(...)` — but `data.map` is still `None`:

```
AttributeError: 'NoneType' object has no attribute 'map'
  File "Plugins/Map/classes.py", line 2776, in generate_points
    node = data.map.get_node_by_uid(node)
```

The plugin process wrapper at `ETS2LA/Plugin/process.py:392` catches it, so it isn't fatal — but every affected plugin logs a full traceback every tick until the map finishes loading. In my logs it came from `AdaptiveCruiseControl.get_next_prefab_traffic_light`, but anything that touches prefab bounding boxes during that window hits the same path.

The fix is a null-guard at the top of the `if isinstance(prefab, Prefab):` branch: if `data` or `data.map` isn't available yet, return `[]`. The caching `points` property at `classes.py:2733`:

```python
@property
def points(self):
    if self._points == []:
        self._points = self.generate_points(prefab=self.prefab)
    return self._points
```

checks `if self._points == []` before calling `generate_points`, so returning `[]` keeps `self._points` in the "not computed yet" state and the next tick retries — no risk of permanently caching a stale empty route. Once `data.map` is populated the original computation runs and the points get cached normally.

No behaviour change in steady state.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update