### PR TITLE
Cache rotation.euler() once per get_path_for call

### DIFF
--- a/Modules/Traffic/classes.py
+++ b/Modules/Traffic/classes.py
@@ -443,8 +443,11 @@ class Vehicle:
     def get_path_for(self, seconds: float) -> Position | None:
         points_per_second = 10
         points = []
+        iterations = int(seconds * points_per_second)
+        if iterations <= 0:
+            return points
         cached_euler = self.rotation.euler()
-        for i in range(0, int(seconds * points_per_second)):
+        for i in range(0, iterations):
             point = self.get_position_in(i / points_per_second, cached_euler=cached_euler)
             if point:
                 points.append(point)

--- a/Modules/Traffic/classes.py
+++ b/Modules/Traffic/classes.py
@@ -413,13 +413,13 @@ class Vehicle:
         center_z = (front_left.z + front_right.z + back_right.z + back_left.z) / 4
         return Position(center_x, center_y, center_z)
 
-    def get_position_in(self, seconds: float) -> Position | None:
+    def get_position_in(self, seconds: float, cached_euler: tuple[float, float, float] | None = None) -> Position | None:
         distance = self.speed * seconds
         if distance == 0:
             return Position(self.position.x, self.position.y, self.position.z)
 
         # x and z are the ground plane, don't care about y
-        pitch, yaw, roll = self.rotation.euler()
+        pitch, yaw, roll = cached_euler if cached_euler is not None else self.rotation.euler()
         yaw = math.radians(yaw)
 
         # adjust based on angular velocity, we assume
@@ -443,8 +443,9 @@ class Vehicle:
     def get_path_for(self, seconds: float) -> Position | None:
         points_per_second = 10
         points = []
+        cached_euler = self.rotation.euler()
         for i in range(0, int(seconds * points_per_second)):
-            point = self.get_position_in(i / points_per_second)
+            point = self.get_position_in(i / points_per_second, cached_euler=cached_euler)
             if point:
                 points.append(point)
 


### PR DESCRIPTION
# Description

`Vehicle.get_position_in` (in `Modules/Traffic/classes.py`) calls `self.rotation.euler()` every invocation. `Quaternion.euler()` does a handful of `math.atan2`/`asin` conversions — not free.

When `get_position_in` is driven from `get_path_for`, it's called inside a tight loop over path points:

```python
def get_path_for(self, seconds: float) -> Position | None:
    points_per_second = 10
    points = []
    for i in range(0, int(seconds * points_per_second)):
        point = self.get_position_in(i / points_per_second)
        ...
```

`self.rotation` doesn't change across that loop, so `euler()` produces the same `(pitch, yaw, roll)` tuple every iteration and the trig work is re-done for nothing.

The change computes the tuple once at the top of `get_path_for` and passes it into `get_position_in` via a new optional kwarg `cached_euler`. When the kwarg is provided, `get_position_in` uses it; otherwise it falls back to the existing `self.rotation.euler()` call — so every existing external caller of `get_position_in` continues to work unchanged.

With e.g. ~20 tracked vehicles and a 2.5 s lookahead (25 points per vehicle at `points_per_second = 10`), that's on the order of 500 `euler()` conversions removed per frame — a meaningful amount for something CollisionAvoidance and the traffic simulation call every tick.

Same rotation in, same euler tuple out, identical downstream computation. No behaviour change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

(None of the above quite fit — this is a performance-only refactor, same behaviour and same API for all existing callers.)