### PR TITLE
Hoist forward_vector norm out of the GetMostInDirection loop

### DIFF
--- a/Plugins/Map/utils/math_helpers.py
+++ b/Plugins/Map/utils/math_helpers.py
@@ -125,6 +125,7 @@ def GetMostInDirection(
     )
     best_index = 0
     best_angle = 180
+    forward_norm = np.linalg.norm(forward_vector)
     for i, point in enumerate(points):
         point_forward_vector = [
             point[0] - truck_position[0],
@@ -132,7 +133,7 @@ def GetMostInDirection(
         ]
         angle = math.acos(
             np.dot(forward_vector, point_forward_vector)
-            / (np.linalg.norm(forward_vector) * np.linalg.norm(point_forward_vector))
+            / (forward_norm * np.linalg.norm(point_forward_vector))
         )
         angle = math.degrees(angle)
         if angle < best_angle:


### PR DESCRIPTION
# Description

`GetMostInDirection` in `Plugins/Map/utils/math_helpers.py` walks the candidate `points` list and, for each one, computes the angle between the truck's `forward_vector` and the vector from the truck to the point.

`forward_vector` is built once before the loop (from `truck_rotation` and the `target_angle` rotation) and is not mutated inside the loop. Its norm is therefore invariant across iterations — but the existing code recomputes `np.linalg.norm(forward_vector)` every iteration in the denominator of `math.acos(...)`.

Hoisting the norm into a local `forward_norm` and reusing it gives bit-identical floats into `math.acos` (same operand vector → same numpy norm result → same division → same angle). The dot product and the per-point norm still happen inside the loop, as they must.

No behaviour change. One `np.linalg.norm` call removed per iteration; `GetMostInDirection` is called on the route-planning path and `points` can be long.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

(None of the above quite fit — this is a performance-only hoist, same output for any input.)