### PR TITLE
Merge the two node_uids loops in GetClosestLanesForPrefab

### DIFF
--- a/Plugins/Map/route/planning.py
+++ b/Plugins/Map/route/planning.py
@@ -145,25 +145,22 @@ def GetClosestLanesForPrefab(next_item: c.Prefab, end_point: c.Position) -> list
         points = next_item.nav_routes[closest_lane_id].points
         start_node = None
         start_node_distance = math.inf
-        for node in [
-            data.map.get_node_by_uid(node_uid) for node_uid in next_item.node_uids
-        ]:
-            distance = math_helpers.DistanceBetweenPoints(
-                (points[0].x, points[0].z), (node.x, node.y)
-            )
-            if distance < start_node_distance:
-                start_node_distance = distance
-                start_node = node
         end_node = None
         end_node_distance = math.inf
         for node in [
             data.map.get_node_by_uid(node_uid) for node_uid in next_item.node_uids
         ]:
-            distance = math_helpers.DistanceBetweenPoints(
+            start_distance = math_helpers.DistanceBetweenPoints(
+                (points[0].x, points[0].z), (node.x, node.y)
+            )
+            if start_distance < start_node_distance:
+                start_node_distance = start_distance
+                start_node = node
+            end_distance = math_helpers.DistanceBetweenPoints(
                 (points[-1].x, points[-1].z), (node.x, node.y)
             )
-            if distance < end_node_distance:
-                end_node_distance = distance
+            if end_distance < end_node_distance:
+                end_node_distance = end_distance
                 end_node = node
 
         if start_node != end_node:


### PR DESCRIPTION
# Description

`GetClosestLanesForPrefab` in `Plugins/Map/route/planning.py` has two back-to-back loops over the same list comprehension of nodes resolved from `next_item.node_uids`. One loop finds `start_node` (closest to `points[0]`), the other finds `end_node` (closest to `points[-1]`). Nothing in the second loop depends on the first — but the list comprehension is built twice and iterated twice.

This merges them into a single pass: build the resolved node list once, compute both the start and end distances inside the same iteration, update each best-so-far independently. Tie-breaking is preserved (both comparisons still use strict `<`), so the first node seen at the minimum distance wins — same as the two-loop version.

No behaviour change. Saves one list comprehension allocation and one extra iteration over `node_uids` per call.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

(None of the above quite fit — performance-only loop consolidation, same output for any input.)