### PR TITLE
Local-bind DistanceBetweenPoints in the prefab lane loop

### DIFF
--- a/Plugins/Map/route/planning.py
+++ b/Plugins/Map/route/planning.py
@@ -129,9 +129,10 @@ def GetClosestRouteSection() -> rc.RouteSection:
 def GetClosestLanesForPrefab(next_item: c.Prefab, end_point: c.Position) -> list[int]:
     closest_lane_ids = []
     closest_point_distance = math.inf
+    _dist = math_helpers.DistanceBetweenPoints
     for lane_id, lane in enumerate(next_item.nav_routes):
         for point in lane.points:
-            distance = math_helpers.DistanceBetweenPoints(
+            distance = _dist(
                 (end_point.x, end_point.y, end_point.z), point.tuple()
             )
             if distance == closest_point_distance:


### PR DESCRIPTION
# Description

`GetClosestLanesForPrefab` in `Plugins/Map/route/planning.py` walks a double-nested loop over every lane in `next_item.nav_routes` and every point in each lane. Inside that loop it calls `math_helpers.DistanceBetweenPoints(...)`. Each call does the module attribute lookup `math_helpers -> DistanceBetweenPoints` every iteration.

Binding the function to a local once above the outer loop (`_dist = math_helpers.DistanceBetweenPoints`) and calling through the local avoids that per-iteration lookup. Both names reference the exact same function object, so call results are byte-identical.

No behaviour change. Small per-iteration win but the loop hits a meaningful total iteration count during route planning.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

(None of the above quite fit — performance-only local binding, identical call results.)