### PR TITLE
Remove dead 'points = points' self-assignment in GetSteering

### DIFF
--- a/Plugins/Map/route/driving.py
+++ b/Plugins/Map/route/driving.py
@@ -228,7 +228,6 @@ def GetSteering():
         data.route_points = points
         return 0
 
-    points = points
     speed = max(data.truck_speed * 3.6, 10)  # Convert to kph
     speed = min(speed, 80)
     # Multiplier is 8 at 10kph and 2 at 80kph


### PR DESCRIPTION
# Description

`Plugins/Map/route/driving.py` had a stray line `points = points` sitting alone on the top-level path of `GetSteering`, between the early-return block and the speed-multiplier calculation. It is a no-op — presumably a leftover from a refactor where the right-hand side used to be something else. Removing it.

No behaviour change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

(None of the above quite fit — dead-code removal, identical behaviour.)