### PR TITLE
Cache norm(v1) and norm(v2) in ACC calculate_curvature

### DIFF
--- a/Plugins/AdaptiveCruiseControl/speed.py
+++ b/Plugins/AdaptiveCruiseControl/speed.py
@@ -34,7 +34,9 @@ def calculate_curvature(points, x, z):
 
         # Angle change
         dot_product = np.dot(v1, v2)
-        norm_product = np.linalg.norm(v1) * np.linalg.norm(v2)
+        norm_v1 = np.linalg.norm(v1)
+        norm_v2 = np.linalg.norm(v2)
+        norm_product = norm_v1 * norm_v2
         if norm_product == 0:
             continue  # Skip to avoid division by zero
         cos_angle = dot_product / norm_product
@@ -42,7 +44,7 @@ def calculate_curvature(points, x, z):
         delta_theta = np.arccos(cos_angle)
 
         # Arc length (average of the two segment lengths)
-        delta_s = (np.linalg.norm(v1) + np.linalg.norm(v2)) / 2
+        delta_s = (norm_v1 + norm_v2) / 2
 
         # Curvature (1/m)
         if delta_s == 0:


### PR DESCRIPTION
# Description

`calculate_curvature` in `Plugins/AdaptiveCruiseControl/speed.py` loops over road points computing per-segment curvature. For each segment it needs both:

- `norm_product = np.linalg.norm(v1) * np.linalg.norm(v2)` as the denominator of the `cos_angle` computation, and
- `delta_s = (np.linalg.norm(v1) + np.linalg.norm(v2)) / 2` as the arc-length average.

Currently `np.linalg.norm(v1)` and `np.linalg.norm(v2)` are each called twice per iteration. Since `np.linalg.norm` is deterministic, computing each once into a local and reusing the locals in both expressions yields byte-identical floats.

No behaviour change — two redundant norm calls removed per loop iteration. The function runs per ACC speed-planning tick, so the saving aggregates.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

(None of the above quite fit — pure redundancy removal; same output for any input.)