### PR TITLE
Eliminate intermediate list in ACC light-filter truck-vector normalization

### DIFF
--- a/Plugins/AdaptiveCruiseControl/main.py
+++ b/Plugins/AdaptiveCruiseControl/main.py
@@ -744,13 +744,12 @@ class Plugin(ETS2LAPlugin):
 
                 # Project to the truck's forward vector
                 # (to get the forward distance to the light)
-                truck_vector_normalized = [truck_vector[0], truck_vector[1]]
                 vector_length = math.sqrt(
-                    truck_vector_normalized[0] ** 2 + truck_vector_normalized[1] ** 2
+                    truck_vector[0] ** 2 + truck_vector[1] ** 2
                 )
                 truck_vector_normalized = [
-                    truck_vector_normalized[0] / vector_length,
-                    truck_vector_normalized[1] / vector_length,
+                    truck_vector[0] / vector_length,
+                    truck_vector[1] / vector_length,
                 ]
 
                 forward_distance = (


### PR DESCRIPTION
# Description

`get_valid_lights` in `Plugins/AdaptiveCruiseControl/main.py` was building an intermediate copy of `truck_vector` just to normalize it:

\`\`\`python
truck_vector_normalized = [truck_vector[0], truck_vector[1]]
vector_length = math.sqrt(
    truck_vector_normalized[0] ** 2 + truck_vector_normalized[1] ** 2
)
truck_vector_normalized = [
    truck_vector_normalized[0] / vector_length,
    truck_vector_normalized[1] / vector_length,
]
\`\`\`

The intermediate `[truck_vector[0], truck_vector[1]]` list isn't needed — `vector_length` can come directly from `truck_vector`, and the normalized list gets assembled in one pass from the same two original values.

Same FP operations on the same values; one list allocation eliminated per light per iteration.

(Note: the identical pattern exists at the gate-filter site a few hundred lines later in the same file. I'm leaving that one untouched here to keep this PR scoped to the light path. Happy to follow up with a second PR for the gate site if you'd like.)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

(None of the above quite fit — small allocation-removal; identical output.)