### PR TITLE
Cache np.linalg.norm(centerline) once in GetSteering

### DIFF
--- a/Plugins/Map/route/driving.py
+++ b/Plugins/Map/route/driving.py
@@ -272,15 +272,15 @@ def GetSteering():
                     data.truck_z - points[0].z,
                 ]
 
+            norm_centerline = np.linalg.norm(centerline)
             lateral_offset = np.cross(
                 truck_position_vector, centerline
-            ) / np.linalg.norm(centerline)
+            ) / norm_centerline
             # data.plugin.tags.lateral_offset = lateral_offset
 
             # Calculate the dot product and the norms
             dot_product = np.dot(forward_vector, centerline)
             norm_forward = np.linalg.norm(forward_vector)
-            norm_centerline = np.linalg.norm(centerline)
 
             # Calculate the cosine of the angle
             cos_angle = dot_product / (norm_forward * norm_centerline)


### PR DESCRIPTION
# Description

`GetSteering` in `Plugins/Map/route/driving.py` was computing `np.linalg.norm(centerline)` **twice** per steering frame — once as the divisor for `lateral_offset`:

\`\`\`python
lateral_offset = np.cross(truck_position_vector, centerline) / np.linalg.norm(centerline)
\`\`\`

and again a few lines later as `norm_centerline` in the `cos_angle` computation. `centerline` doesn't change between the two call sites, and `np.linalg.norm` is deterministic, so computing once into `norm_centerline` at the top and reusing it yields byte-identical floats.

No behaviour change; one `numpy.linalg.norm` call removed per steering tick.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

(None of the above quite fit — simple redundancy removal.)