### PR TITLE
Hoist -yaw into neg_yaw in Trailer.get_corners

### DIFF
--- a/Modules/Traffic/classes.py
+++ b/Modules/Traffic/classes.py
@@ -219,10 +219,11 @@ class Trailer:
 
         # Rotate the corners
         pitch, yaw, roll = self.rotation.euler()
-        front_left = rotate_around_point(front_left, ground_middle, pitch, -yaw, 0)
-        front_right = rotate_around_point(front_right, ground_middle, pitch, -yaw, 0)
-        back_right = rotate_around_point(back_right, ground_middle, pitch, -yaw, 0)
-        back_left = rotate_around_point(back_left, ground_middle, pitch, -yaw, 0)
+        neg_yaw = -yaw
+        front_left = rotate_around_point(front_left, ground_middle, pitch, neg_yaw, 0)
+        front_right = rotate_around_point(front_right, ground_middle, pitch, neg_yaw, 0)
+        back_right = rotate_around_point(back_right, ground_middle, pitch, neg_yaw, 0)
+        back_left = rotate_around_point(back_left, ground_middle, pitch, neg_yaw, 0)
 
         front_left = Position(*front_left)
         front_right = Position(*front_right)


### PR DESCRIPTION
# Description

`Trailer.get_corners` in `Modules/Traffic/classes.py` rotates all four corner points via `rotate_around_point(..., pitch, -yaw, 0)`. The same `-yaw` is recomputed in each of the four call sites.

Floating-point negation is exact, so computing `neg_yaw = -yaw` once and passing the local into all four calls produces byte-identical rotated corners.

No behaviour change; three redundant FP negations removed per `Trailer.get_corners` call. The function runs per visible trailer per frame, so the saving aggregates.

Note: `Vehicle.get_corners` in the same file has the identical pattern and would benefit from the same hoist — I'm leaving that for a follow-up PR to keep this one focused on the Trailer path.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

(None of the above quite fit — trivial hoist; identical output for any input.)