### PR TITLE
Drop time.sleep(0.001) calls from ExternalDataUpdateThread

### DIFF
--- a/Plugins/Map/data.py
+++ b/Plugins/Map/data.py
@@ -185,28 +185,23 @@ def ExternalDataUpdateThread():
     external_data["prefabs"] = []
     for prefab in current_sector_prefabs:
         external_data["prefabs"].append(prefab.json())
-        time.sleep(0.001)
-    
+
     external_data["roads"] = []
     for road in current_sector_roads:
         external_data["roads"].append(road.json())
-        time.sleep(0.001)    
-    
+
     external_data["models"] = []
     for model in current_sector_models:
         external_data["models"].append(model.json())
-        time.sleep(0.001)
-        
+
     external_data["signs"] = []
     for sign in current_sector_signs:
         external_data["signs"].append(sign.json())
-        time.sleep(0.001)
-        
+
     if send_elevation_data:
         external_data["elevations"] = []
         for elevation in current_sector_elevations:
             external_data["elevations"].append(elevation.json())
-            time.sleep(0.001)
 
     external_data_changed = True
     external_data_time = time.perf_counter()


### PR DESCRIPTION
# Description

`ExternalDataUpdateThread` in `Plugins/Map/data.py` runs on every sector crossing and builds the frontend's `external_data` dict from five per-sector lists (prefabs, roads, models, signs, optionally elevations). Each of those five `for …: append(...)` loops had a `time.sleep(0.001)` call per iteration.

On Windows, `time.sleep(0.001)` doesn't actually sleep 1 ms — it resolves to whatever the current system-timer tick is (commonly 1-15 ms depending on what else on the system has called `timeBeginPeriod`). With typical sector contents that accumulates to roughly 100-500 ms of blocking per sector crossing in the worker thread — with no observable value, since the thread isn't sharing a lock with any other code, and `external_data` is only read after the thread sets `external_data_changed = True` at the very end.

Removing the sleeps changes only execution time; the resulting `external_data` dict is byte-for-byte identical to the pre-change output.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

(None of the above quite fit — removing unnecessary throttling; same output.)