### PR TITLE
Fix IndexError in end_node/start_node when lane_index exceeds nav_routes length

### DIFF
--- a/Plugins/Map/route/classes.py
+++ b/Plugins/Map/route/classes.py
@@ -73,9 +73,10 @@ class RouteSection:
             # Find the index of the node that matches the first curve
             nav_routes = self.items[0].item.prefab_description.nav_routes
             if not nav_routes:
-                self._start_node = data.map.get_node_by_uid(self.items[0].item.node_uids[0])
-                return self._start_node
+                return data.map.get_node_by_uid(self.items[0].item.node_uids[0])
             lane_idx = min(self.lane_index, len(nav_routes) - 1)
+            if lane_idx != self.lane_index:
+                return data.map.get_node_by_uid(self.items[0].item.node_uids[0])
             nav_route = nav_routes[lane_idx]
             first_curve = nav_route.curves[0]
             index = self.items[0].item.prefab_description.nav_curves.index(first_curve)
@@ -101,9 +102,10 @@ class RouteSection:
             # Find the index of the node that matches the last curve
             nav_routes = self.items[0].item.prefab_description.nav_routes
             if not nav_routes:
-                self._end_node = data.map.get_node_by_uid(self.items[0].item.node_uids[-1])
-                return self._end_node
+                return data.map.get_node_by_uid(self.items[0].item.node_uids[-1])
             lane_idx = min(self.lane_index, len(nav_routes) - 1)
+            if lane_idx != self.lane_index:
+                return data.map.get_node_by_uid(self.items[0].item.node_uids[-1])
             nav_route = nav_routes[lane_idx]
             last_curve = nav_route.curves[-1]
             index = self.items[0].item.prefab_description.nav_curves.index(last_curve)

--- a/Plugins/Map/route/classes.py
+++ b/Plugins/Map/route/classes.py
@@ -71,9 +71,12 @@ class RouteSection:
             return self._start_node
         if isinstance(self.items[0].item, c.Prefab):
             # Find the index of the node that matches the first curve
-            nav_route = self.items[0].item.prefab_description.nav_routes[
-                self.lane_index
-            ]
+            nav_routes = self.items[0].item.prefab_description.nav_routes
+            if not nav_routes:
+                self._start_node = data.map.get_node_by_uid(self.items[0].item.node_uids[0])
+                return self._start_node
+            lane_idx = min(self.lane_index, len(nav_routes) - 1)
+            nav_route = nav_routes[lane_idx]
             first_curve = nav_route.curves[0]
             index = self.items[0].item.prefab_description.nav_curves.index(first_curve)
             node_index = 0
@@ -96,9 +99,12 @@ class RouteSection:
             return self._end_node
         if isinstance(self.items[0].item, c.Prefab):
             # Find the index of the node that matches the last curve
-            nav_route = self.items[0].item.prefab_description.nav_routes[
-                self.lane_index
-            ]
+            nav_routes = self.items[0].item.prefab_description.nav_routes
+            if not nav_routes:
+                self._end_node = data.map.get_node_by_uid(self.items[0].item.node_uids[-1])
+                return self._end_node
+            lane_idx = min(self.lane_index, len(nav_routes) - 1)
+            nav_route = nav_routes[lane_idx]
             last_curve = nav_route.curves[-1]
             index = self.items[0].item.prefab_description.nav_curves.index(last_curve)
             node_index = len(self.items[0].item.prefab_description.nodes) - 1

--- a/Plugins/NavigationSockets/main.py
+++ b/Plugins/NavigationSockets/main.py
@@ -211,7 +211,10 @@ class Plugin(ETS2LAPlugin):
 
         index = self.tags.next_intersection_lane
         index: int = self.tags.merge(index)
-        if index is None:
+        if index is None or not isinstance(index, int):
+            return
+
+        if index >= len(prefab.nav_routes):
             return
 
         target_route = prefab.nav_routes[index]


### PR DESCRIPTION
Clamps lane_index to the valid range of nav_routes to prevent IndexError when a prefab has fewer nav_routes than the current lane_index value. Also handles the edge case where nav_routes is empty.