### PR TITLE
Add check for zero weight division

### DIFF
--- a/ETS2LA.Game/Output/Output.cs
+++ b/ETS2LA.Game/Output/Output.cs
@@ -281,6 +281,7 @@ public class GameOutput
                 List<Tuple<float, float>> values = kvp.Value;
 
                 float totalWeight = values.Sum(v => v.Item1);
+                if (totalWeight == 0f) continue;
                 float weightedValue = values.Sum(v => v.Item1 * v.Item2) / totalWeight;
                 weightedValue = Math.Clamp(weightedValue, -1f, 1f);
 


### PR DESCRIPTION
# Description
If totalWeight ends up at 0, the divide will be NaN. Math.Clamp doesn't catch it cuz NaN comparisons are always false so it passes in the game's steering/acceleration memory.

So I added a `continue` to skip the channel when totalWeight is 0.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
