### PR TITLE
Fixed "InternalVisualization" so it correctly extracts roads and prefabs from parsed map data.

### DIFF
--- a/Plugins/InternalVisualization/Program.cs
+++ b/Plugins/InternalVisualization/Program.cs
@@ -93,8 +93,8 @@ namespace InternalVisualization
             if(fs != null) SiiFileHandler.Current.SetFileSystem(fs);
             if(fs != null) PpdFileHandler.Current.SetFileSystem(fs);
 
-            _roads = _mapData.MapItems.Where(item => item is Road).Cast<Road>().ToArray();
-            _prefabs = _mapData.MapItems.Where(item => item is Prefab).Cast<Prefab>().ToArray();
+            _roads = _mapData.MapItems.Values.OfType<Road>().ToArray();
+            _prefabs = _mapData.MapItems.Values.OfType<Prefab>().ToArray();
 
             if (_telemetryData == null) return;
             Vector3Double center = _telemetryData.truckPlacement.coordinate;


### PR DESCRIPTION
# Description
1. Fixes incorrect empty road/prefab arrays in InternalVisualization.
2. Removes compiler warnings 🙏🙏

## Type of change
Check the relavent options (place an "x" between the brackets)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
