### PR TITLE
Fix MemoryReader.ReadChar stopping at null terminator

### DIFF
--- a/ETS2LA.Shared/Memory.cs
+++ b/ETS2LA.Shared/Memory.cs
@@ -114,10 +114,8 @@ namespace ETS2LA.Shared
             for (int i = 0; i < count; i++)
             {
                 char c = (char)memory[offset + i];
-                if (c != '\0') // Skip null characters
-                {
-                    charBuilder.Append(c);
-                }
+                if (c == '\0') break; // C strings terminate at first null
+                charBuilder.Append(c);
             }
             return charBuilder.ToString();
         }


### PR DESCRIPTION
# Description
ReadChar skipped null bytes instead of terminating, appending garbage bytes into every returned string

Telemetry strings should actually be clean now

## Type of change
Check the relavent options (place an "x" between the brackets)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
