### PR TITLE
Fix multiplayerTimeOffset type

### DIFF
--- a/ETS2LA.Telemetry/Classes.cs
+++ b/ETS2LA.Telemetry/Classes.cs
@@ -380,7 +380,7 @@ namespace ETS2LA.Telemetry
         public ulong time;
         public ulong simulatedTime;
         public ulong renderTime;
-        public int multiplayerTimeOffset;
+        public long multiplayerTimeOffset;
 
         // Other categories
         public SCSValues scsValues;

--- a/ETS2LA.Telemetry/Classes.cs
+++ b/ETS2LA.Telemetry/Classes.cs
@@ -380,7 +380,7 @@ namespace ETS2LA.Telemetry
         public ulong time;
         public ulong simulatedTime;
         public ulong renderTime;
-        public float multiplayerTimeOffset;
+        public int multiplayerTimeOffset;
 
         // Other categories
         public SCSValues scsValues;

--- a/ETS2LA.Telemetry/Program.cs
+++ b/ETS2LA.Telemetry/Program.cs
@@ -181,7 +181,7 @@ public class GameTelemetry
         _currentData.time = _reader.ReadLongLong(offset); offset += 8;
         _currentData.simulatedTime = _reader.ReadLongLong(offset); offset += 8;
         _currentData.renderTime = _reader.ReadLongLong(offset); offset += 8;
-        _currentData.multiplayerTimeOffset = _reader.ReadLongLong(offset); offset += 8;
+        _currentData.multiplayerTimeOffset = _reader.ReadInt(offset); offset += 8;
 
         // SCSValues
         _currentData.scsValues.telemetryPluginRevision = _reader.ReadInt(offset); offset += 4;


### PR DESCRIPTION
# Description
Fixes wrong type on multiplayerTimeOffset, it was a float read as ulong, but scs-telemetry writes signed int.
## Type of change
Check the relavent options (place an "x" between the brackets)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
