### PR TITLE
Add check for non-positive road length

### DIFF
--- a/Plugins/InternalVisualization/Renderers/Roads.cs
+++ b/Plugins/InternalVisualization/Renderers/Roads.cs
@@ -59,6 +59,7 @@ public class RoadsRenderer : Renderer
             float resolution = RoadUtils.GetRoadResolution(road);
             float length = road.Length;
 
+            if (length <= 0) continue;
             float stepLength = 1 / length * resolution;
 
             Vector2 minScreenPos = new Vector2(float.MaxValue, float.MaxValue);


### PR DESCRIPTION
# Description
Skips zero-length roads so the road visualizer doesn’t break.
## Type of change
Check the relavent options (place an "x" between the brackets)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
