### PR TITLE
Fix plugin manager initialization order

### DIFF
--- a/ETS2LA.UI/Views/ManagerView.axaml.cs
+++ b/ETS2LA.UI/Views/ManagerView.axaml.cs
@@ -21,12 +21,13 @@ public partial class ManagerView : UserControl, INotifyPropertyChanged
 
     public ManagerView(PluginManagerService service)
     {
+        _pluginService = service;
+
         if (!service.backend.IsLoaded) service.backend.OnBackendLoaded += (s, e) => UpdatePluginList();
         else UpdatePluginList();
-        
+
         InitializeComponent();
         DataContext = this;
-        _pluginService = service;
     }
 
     private void TogglePluginClick(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
# Description
_pluginService was used before it was assigned in the ManagerView constructor

## Type of change
Check the relavent options (place an "x" between the brackets)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
