### PR TITLE
Fix ReloadPlugins not unloading existing plugins before loading

### DIFF
--- a/ETS2LA.UI/Services/PluginManagerService.cs
+++ b/ETS2LA.UI/Services/PluginManagerService.cs
@@ -28,6 +28,7 @@ public sealed class PluginManagerService
 
     public void ReloadPlugins()
     {
+        backend.pluginHandler?.UnloadPlugins();
         backend.pluginHandler?.LoadPlugins();
     }
 


### PR DESCRIPTION
# Description
ReloadPlugins called LoadPlugins without unloading first 

## Type of change
Check the relavent options (place an "x" between the brackets)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
