### PR TITLE
Fix plugin tick loop CPU spike after slow ticks

### DIFF
--- a/ETS2LA.Shared/Shared.cs
+++ b/ETS2LA.Shared/Shared.cs
@@ -118,6 +118,10 @@ namespace ETS2LA.Shared
                 {
                     Console.WriteLine($"Error in plugin {Info.Name} Tick: {ex}");
                 }
+
+                if (next < sw.Elapsed.TotalMilliseconds)
+                    next = sw.Elapsed.TotalMilliseconds;
+                
                 double remaining = next - sw.Elapsed.TotalMilliseconds;
 
                 // Use Thread.Sleep for the bigger part of the sleep.


### PR DESCRIPTION
# Description
I noticed that if a plugins Tick() takes too long (or the GC pauses), the loop starts 
running ticks one after another with no sleep in between, and it maxes out a CPU core.

I added a check that sets "next" back to the current
time if its fallen behind, so it goes back to ticking at the normal rate.

## Type of change
Check the relavent options (place an "x" between the brackets)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
