### PR TITLE
Fix Logger.Fatal not logging the exception

### DIFF
--- a/ETS2LA.Logging/Program.cs
+++ b/ETS2LA.Logging/Program.cs
@@ -172,7 +172,7 @@ namespace ETS2LA.Logging
                 return;
             }
 
-            WriteLogLine("FTL", message, "bold red", filePath, lineNumber);
+            WriteLogLine("FTL", message, "bold red", filePath, lineNumber, ex);
             lastLine = message;
             repeatCount = 0;
         }


### PR DESCRIPTION
# Description
Logger.Fatal accepted an Exception but never forwarded it to WriteLogLine
## Type of change
Check the relavent options (place an "x" between the brackets)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
