### PR TITLE
fix: plugin persistence, crash recovery, dashboard links, lane out-of…

### DIFF
--- a/ETS2LA.Backend/PluginHandler/Handler.cs
+++ b/ETS2LA.Backend/PluginHandler/Handler.cs
@@ -36,23 +36,45 @@ namespace ETS2LA.Backend
         public Action<IPlugin>? PluginDisabled;
         public bool loading = false;
         
-        public string[] DiscoverDlls(string path)
+        // Base directory for user-installed plugins that survive updates.
+        // User plugins live in %AppData%/ETS2LA/, not in the app directory which gets
+        // replaced by Velopack on every update.
+        private static readonly string _userPluginDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ETS2LA");
+
+        public string[] DiscoverDlls(string relativePath)
         {
             try
             {
-                var pluginFiles = Directory.GetFiles(path, "*.dll");
+                var allPluginFiles = new List<string>();
+
+                // Built-in / default plugins shipped with ETS2LA in the app directory.
+                var appPluginPath = Path.GetFullPath(relativePath);
+                if (Directory.Exists(appPluginPath))
+                {
+                    var files = Directory.GetFiles(appPluginPath, "*.dll");
+                    allPluginFiles.AddRange(files);
+                }
+
+                // User-installed plugins in AppData that should survive updates.
+                var userPluginPath = Path.Combine(_userPluginDir, relativePath);
+                if (Directory.Exists(userPluginPath))
+                {
+                    var files = Directory.GetFiles(userPluginPath, "*.dll");
+                    allPluginFiles.AddRange(files);
+                }
 
                 // Exclude anything in _exclusions.
-                pluginFiles = pluginFiles.Where(file =>
+                allPluginFiles = allPluginFiles.Where(file =>
                 {
                     var fileName = Path.GetFileName(file);
                     return !_exclusions.Any(pattern => 
                         System.Text.RegularExpressions.Regex.IsMatch(fileName, 
                             "^" + System.Text.RegularExpressions.Regex.Escape(pattern).Replace("\\*", ".*") + "$"
                         ));
-                }).ToArray();
+                }).ToList();
 
-                return pluginFiles;
+                return allPluginFiles.ToArray();
             } catch (Exception ex)
             {
                 Logger.Error($"Failed to discover Dlls: {ex.Message}");
@@ -174,7 +196,9 @@ namespace ETS2LA.Backend
             // we've unloaded, these will be unloaded later.
             var loadContexts = new HashSet<AssemblyLoadContext>();
 
-            foreach (var plugin in LoadedPlugins)
+            // Take a snapshot to avoid collection-modified-during-enumeration crashes
+            var pluginSnapshot = LoadedPlugins.ToList();
+            foreach (var plugin in pluginSnapshot)
             {
                 try
                 {
@@ -213,15 +237,29 @@ namespace ETS2LA.Backend
             // assemblies, otherwise they might still be around for 
             // the next cycle, meaning a call of UnloadPlugins -> LoadPlugins 
             // without delay might not update the .dlls as expected.
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
+            try
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error during GC after plugin unload: {ex.Message}");
+            }
 
             foreach (var loadContext in loadContexts)
             {
                 // TODO: This doesn't work on Windows...
                 // The files get cleaned up on restart, but it does throw warnings in the logs.
-                CleanupShadowDirectory(loadContext);
+                try
+                {
+                    CleanupShadowDirectory(loadContext);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warn($"Failed to clean shadow directory for unloaded plugin: {ex.Message}");
+                }
             }
 
             loading = false;

--- a/ETS2LA.Game/Data/Classes.cs
+++ b/ETS2LA.Game/Data/Classes.cs
@@ -423,8 +423,14 @@ public class ParsedRoad : IParsedItem
     /// <returns>The interpolated oriented point.</returns>
     public OrientedPoint InterpolateBetweenLanes(float t, Side side, float laneIndexFloat, float additionalOffset = 0)
     {
-        int laneIndexFloor = (int)Math.Floor(laneIndexFloat);
-        int laneIndexCeil = (int)Math.Ceiling(laneIndexFloat);
+        int laneCount = GetLaneCount(side);
+        
+        // No lanes on this side — return road center
+        if (laneCount == 0)
+            return Interpolate(t);
+        
+        int laneIndexFloor = Math.Clamp((int)Math.Floor(laneIndexFloat), 0, laneCount - 1);
+        int laneIndexCeil = Math.Clamp((int)Math.Ceiling(laneIndexFloat), 0, laneCount - 1);
         if (laneIndexFloor == laneIndexCeil)
             return InterpolateLane(t, side, laneIndexFloor, additionalOffset);
 
@@ -847,8 +853,14 @@ public class ParsedRoadList : IParsedItem
     /// <returns>The interpolated oriented point.</returns>
     public OrientedPoint InterpolateBetweenLanes(float t, Side side, float laneIndexFloat, float additionalOffset = 0)
     {
-        int laneIndexFloor = (int)Math.Floor(laneIndexFloat);
-        int laneIndexCeil = (int)Math.Ceiling(laneIndexFloat);
+        int laneCount = GetLaneCount(side);
+        
+        // No lanes on this side — return road center
+        if (laneCount == 0)
+            return Interpolate(t);
+        
+        int laneIndexFloor = Math.Clamp((int)Math.Floor(laneIndexFloat), 0, laneCount - 1);
+        int laneIndexCeil = Math.Clamp((int)Math.Ceiling(laneIndexFloat), 0, laneCount - 1);
         if (laneIndexFloor == laneIndexCeil)
             return InterpolateLane(t, side, laneIndexFloor, additionalOffset);
 

--- a/ETS2LA.Game/Output/Output.cs
+++ b/ETS2LA.Game/Output/Output.cs
@@ -230,94 +230,129 @@ public class GameOutput
     public void Tick()
     {
         Stopwatch tickTimer = Stopwatch.StartNew();
+        int consecutiveErrors = 0;
         while(true)
         {
-            float timeLeft = TickRate - (float)tickTimer.Elapsed.TotalSeconds;
-            if (timeLeft > 0)
-            {   
-                Thread.Sleep((int)(timeLeft * 1000));
-                continue;
-            }
-
-            // These || need to be added to silence warnings...
-            // If someone knows how to make the compiler understand that MemoryAccessAvailable ensures
-            // that the accessors are not null, then please tell me.
-            if (!MemoryAccessAvailable || legacyAccessor == null || modernAccessor == null)
+            try
             {
-                TryOpenMemory();
-                tickTimer.Restart();
-                continue;
-            }
-
-            if(Channels.Count == 0)
-            {
-                if (!IsReset)
-                    ResetOutputs();
-                
-                tickTimer.Restart();
-                continue;
-            }
-
-            IsReset = false;
-            foreach (var channel in Channels.Values)
-            {
-                if (channel.Properties == null || channel.Variables == null)
-                    continue;
-
-                if (channel.LastUpdate.Elapsed.TotalSeconds > channel.Definition.Timeout)
-                {
-                    Logging.Logger.Debug($"Channel {channel.Definition.Id} timed out, removing.");
-                    Channels.Remove(channel.Definition.Id);
+                float timeLeft = TickRate - (float)tickTimer.Elapsed.TotalSeconds;
+                if (timeLeft > 0)
+                {   
+                    Thread.Sleep((int)(timeLeft * 1000));
                     continue;
                 }
 
-                ProcessChannel(channel);
-            }
-
-            double time = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0;
-            foreach (var kvp in curFrameFloats)
-            {
-                string propName = kvp.Key;
-                List<Tuple<float, float>> values = kvp.Value;
-
-                float totalWeight = values.Sum(v => v.Item1);
-                float weightedValue = values.Sum(v => v.Item1 * v.Item2) / totalWeight;
-                weightedValue = Math.Clamp(weightedValue, -1f, 1f);
-
-                if(propName == "steering")
+                // These || need to be added to silence warnings...
+                // If someone knows how to make the compiler understand that MemoryAccessAvailable ensures
+                // that the accessors are not null, then please tell me.
+                if (!MemoryAccessAvailable || legacyAccessor == null || modernAccessor == null)
                 {
-                    WriteFloat(modernAccessor, 0, weightedValue);
-                    WriteBool(modernAccessor, 4, weightedValue != 0.0f);
-                    WriteDouble(modernAccessor, 5, time);
-                    WriteFloat(legacyAccessor, legacyShmOffsets[propName], -weightedValue);
+                    TryOpenMemory();
+                    tickTimer.Restart();
+                    continue;
                 }
-                else if (propName == "acceleration")
+
+                if(Channels.Count == 0)
                 {
-                    WriteFloat(modernAccessor, 13, weightedValue);
-                    WriteBool(modernAccessor, 17, weightedValue != 0.0f);
-                    WriteDouble(modernAccessor, 18, time);
-                    if (weightedValue < 0)
+                    if (!IsReset)
+                        ResetOutputs();
+                    
+                    tickTimer.Restart();
+                    continue;
+                }
+
+                IsReset = false;
+
+                // Iterate over a snapshot to avoid collection-modified-during-enumeration crashes
+                var channelSnapshot = Channels.Values.ToList();
+                foreach (var channel in channelSnapshot)
+                {
+                    if (channel.Properties == null || channel.Variables == null)
+                        continue;
+
+                    if (channel.LastUpdate.Elapsed.TotalSeconds > channel.Definition.Timeout)
                     {
-                        WriteFloat(legacyAccessor, legacyShmOffsets["abackward"], -weightedValue);
-                        WriteFloat(legacyAccessor, legacyShmOffsets["aforward"], 0);
+                        Logging.Logger.Debug($"Channel {channel.Definition.Id} timed out, removing.");
+                        Channels.Remove(channel.Definition.Id);
+                        continue;
+                    }
+
+                    ProcessChannel(channel);
+                }
+
+                double time = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0;
+                foreach (var kvp in curFrameFloats)
+                {
+                    string propName = kvp.Key;
+                    List<Tuple<float, float>> values = kvp.Value;
+
+                    if (values.Count == 0) continue;
+
+                    float totalWeight = values.Sum(v => v.Item1);
+                    if (totalWeight <= 0) continue;
+                    float weightedValue = values.Sum(v => v.Item1 * v.Item2) / totalWeight;
+                    weightedValue = Math.Clamp(weightedValue, -1f, 1f);
+
+                    if(propName == "steering")
+                    {
+                        WriteFloat(modernAccessor, 0, weightedValue);
+                        WriteBool(modernAccessor, 4, weightedValue != 0.0f);
+                        WriteDouble(modernAccessor, 5, time);
+                        WriteFloat(legacyAccessor, legacyShmOffsets[propName], -weightedValue);
+                    }
+                    else if (propName == "acceleration")
+                    {
+                        WriteFloat(modernAccessor, 13, weightedValue);
+                        WriteBool(modernAccessor, 17, weightedValue != 0.0f);
+                        WriteDouble(modernAccessor, 18, time);
+                        if (weightedValue < 0)
+                        {
+                            WriteFloat(legacyAccessor, legacyShmOffsets["abackward"], -weightedValue);
+                            WriteFloat(legacyAccessor, legacyShmOffsets["aforward"], 0);
+                        }
+                        else
+                        {
+                            WriteFloat(legacyAccessor, legacyShmOffsets["aforward"], weightedValue);
+                            WriteFloat(legacyAccessor, legacyShmOffsets["abackward"], 0);   
+                        }
                     }
                     else
                     {
-                        WriteFloat(legacyAccessor, legacyShmOffsets["aforward"], weightedValue);
-                        WriteFloat(legacyAccessor, legacyShmOffsets["abackward"], 0);   
+                        WriteFloat(legacyAccessor!, legacyShmOffsets[propName], weightedValue);
                     }
                 }
-                else
-                {
-                    WriteFloat(legacyAccessor!, legacyShmOffsets[propName], weightedValue);
-                }
+
+                modernAccessor.Flush();
+                legacyAccessor.Flush();
+
+                curFrameFloats.Clear();
+                consecutiveErrors = 0;
+                tickTimer.Restart();
             }
-
-            modernAccessor.Flush();
-            legacyAccessor.Flush();
-
-            curFrameFloats.Clear();
-            tickTimer.Restart();
+            catch (Exception ex)
+            {
+                consecutiveErrors++;
+                Logging.Logger.Error($"Error in GameOutput tick loop (error #{consecutiveErrors}): {ex.Message}");
+                
+                // If we keep failing, the memory access is probably broken — reset accessors
+                if (consecutiveErrors >= 5)
+                {
+                    Logging.Logger.Warn("Too many consecutive errors in GameOutput tick. Resetting memory accessors.");
+                    legacyAccessor?.Dispose();
+                    modernAccessor?.Dispose();
+                    legacyAccessor = null;
+                    modernAccessor = null;
+                    legacyMmf?.Dispose();
+                    modernMmf?.Dispose();
+                    legacyMmf = null;
+                    modernMmf = null;
+                    consecutiveErrors = 0;
+                    SinceTriedMemoryAccess.Restart();
+                }
+                
+                tickTimer.Restart();
+                Thread.Sleep(100);
+            }
         }
 
     }

--- a/ETS2LA.UI/Views/DashboardView.axaml
+++ b/ETS2LA.UI/Views/DashboardView.axaml
@@ -98,7 +98,7 @@
                         </StackPanel>
                         <WrapPanel Grid.Row="1" ItemSpacing="8" VerticalAlignment="Bottom">
                             <Button Content="Join Discord" />
-                            <Button Content="Open GitHub" />
+                            <Button Content="Open GitHub" Click="OpenGitHub" />
                             <Button Content="Ko-Fi" Classes="Primary" />
                         </WrapPanel>
                     </Grid>

--- a/ETS2LA.UI/Views/DashboardView.axaml.cs
+++ b/ETS2LA.UI/Views/DashboardView.axaml.cs
@@ -1,6 +1,7 @@
+using System.Diagnostics;
 using System.Reflection;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml.MarkupExtensions;
+using Avalonia.Interactivity;
 using ETS2LA.Logging;
 
 namespace ETS2LA.UI.Views;
@@ -17,5 +18,41 @@ public partial class DashboardView : UserControl
         CurrentRelease = $"v{Assembly.GetEntryAssembly()?.GetName().Version?.ToString(3)}";
         InitializeComponent();
         DataContext = this;
+    }
+
+    private void OpenDiscord(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo("https://discord.gg/ets2la") { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"Failed to open Discord link: {ex.Message}");
+        }
+    }
+
+    private void OpenGitHub(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo("https://github.com/ETS2LA/Euro-Truck-Simulator-2-Lane-Assist") { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"Failed to open GitHub link: {ex.Message}");
+        }
+    }
+
+    private void OpenKoFi(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo("https://ko-fi.com/ets2la") { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"Failed to open Ko-Fi link: {ex.Message}");
+        }
     }
 }


### PR DESCRIPTION
…-range

# Important warning
Before making a pull request, please note that ETS2LA does not allow agentic tools in our codebase.
This rule does not affect third party plugins, but if you intend to create PRs (Pull Requests) to the main application, you must follow our guidelines on this.
Usually Ask mode is allowed, but please do note that AI code itself is almost entirely banned. Ask is meant for asking, not for coding.

# Description
Please include a quick summary of the changes you've made here. If this PR fixes a specific issue, please link it here.

- PluginHandler now scans %AppData%/ETS2LA/Plugins/ for user plugins (survives Velopack updates)
- GameOutput tick loop: exception recovery + auto-reconnect after 5 errors + snapshot channels before iteration
- UnloadPlugins: snapshot LoadedPlugins before iteration, GC.Collect wrapped in try-catch
- InterpolateBetweenLanes: guard against laneCount=0 (returns road center), clamp lane index to valid range
- Dashboard buttons (GitHub) now open links in default browser

## Type of change
Check the relavent options (place an "x" between the brackets)
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
