### PR TITLE
Add thread safety to logging methods

### DIFF
--- a/ETS2LA.Logging/Program.cs
+++ b/ETS2LA.Logging/Program.cs
@@ -13,6 +13,8 @@ namespace ETS2LA.Logging
         public static string lastLine = "";
         public static int repeatCount = 0;
 
+        private static readonly object _logLock = new();
+
         public static event Action<Tuple<string, string>> OnLog;
         static Logger()
         {
@@ -99,15 +101,18 @@ namespace ETS2LA.Logging
             [CallerLineNumber] int lineNumber = 0
         )
         {
-            if (message == lastLine)
+            lock (_logLock)
             {
-                PrintRepeating(message);
-                return;
-            }
+                if (message == lastLine)
+                {
+                    PrintRepeating(message);
+                    return;
+                }
 
-            WriteLogLine("DBG", message, "grey", filePath, lineNumber);
-            lastLine = message;
-            repeatCount = 0;
+                WriteLogLine("DBG", message, "grey", filePath, lineNumber);
+                lastLine = message;
+                repeatCount = 0;
+            }
         }
         public static void Info(
             string message,
@@ -115,15 +120,18 @@ namespace ETS2LA.Logging
             [CallerLineNumber] int lineNumber = 0
         )
         {
-            if (message == lastLine)
+            lock (_logLock)
             {
-                PrintRepeating(message);
-                return;
-            }
+                if (message == lastLine)
+                {
+                    PrintRepeating(message);
+                    return;
+                }
 
-            WriteLogLine("INF", message, "blue", filePath, lineNumber);
-            lastLine = message;
-            repeatCount = 0;
+                WriteLogLine("INF", message, "blue", filePath, lineNumber);
+                lastLine = message;
+                repeatCount = 0;
+            }
         }
 
         public static void Warn(
@@ -132,15 +140,18 @@ namespace ETS2LA.Logging
             [CallerLineNumber] int lineNumber = 0
         )
         {
-            if (message == lastLine)
+            lock (_logLock)
             {
-                PrintRepeating(message);
-                return;
-            }
+                if (message == lastLine)
+                {
+                    PrintRepeating(message);
+                    return;
+                }
 
-            WriteLogLine("WRN", message, "yellow", filePath, lineNumber);
-            lastLine = message;
-            repeatCount = 0;
+                WriteLogLine("WRN", message, "yellow", filePath, lineNumber);
+                lastLine = message;
+                repeatCount = 0;
+            }
         }
 
         public static void Error(
@@ -149,15 +160,18 @@ namespace ETS2LA.Logging
             [CallerLineNumber] int lineNumber = 0
         )
         {
-            if (message == lastLine)
+            lock (_logLock)
             {
-                PrintRepeating(message);
-                return;
-            }
+                if (message == lastLine)
+                {
+                    PrintRepeating(message);
+                    return;
+                }
 
-            WriteLogLine("ERR", message, "red", filePath, lineNumber);
-            lastLine = message;
-            repeatCount = 0;
+                WriteLogLine("ERR", message, "red", filePath, lineNumber);
+                lastLine = message;
+                repeatCount = 0;
+            }
         }
 
         public static void Fatal(
@@ -166,15 +180,18 @@ namespace ETS2LA.Logging
             [CallerLineNumber] int lineNumber = 0
         )
         {
-            if (message == lastLine)
+            lock (_logLock)
             {
-                PrintRepeating(message);
-                return;
-            }
+                if (message == lastLine)
+                {
+                    PrintRepeating(message);
+                    return;
+                }
 
-            WriteLogLine("FTL", message, "bold red", filePath, lineNumber, ex);
-            lastLine = message;
-            repeatCount = 0;
+                WriteLogLine("FTL", message, "bold red", filePath, lineNumber, ex);
+                lastLine = message;
+                repeatCount = 0;
+            }
         }
 
         public static void Success(
@@ -183,15 +200,18 @@ namespace ETS2LA.Logging
             [CallerLineNumber] int lineNumber = 0
         )
         {
-            if (message == lastLine)
+            lock (_logLock)
             {
-                PrintRepeating(message);
-                return;
-            }
+                if (message == lastLine)
+                {
+                    PrintRepeating(message);
+                    return;
+                }
 
-            WriteLogLine("OKK", message, "bold green", filePath, lineNumber);
-            lastLine = message;
-            repeatCount = 0;
+                WriteLogLine("OKK", message, "bold green", filePath, lineNumber);
+                lastLine = message;
+                repeatCount = 0;
+            }
         }
     }
 }


### PR DESCRIPTION
# Description
Added a lock around the log methods so multiple threads can't write at once. 
Fixes messy console output when plugins log at the same time.

## Type of change
Check the relavent options (place an "x" between the brackets)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
