### PR TITLE
Reuse JSON serializer options in Traffic channel

### DIFF
--- a/Plugins/VisualizationSockets/Channels/Traffic.cs
+++ b/Plugins/VisualizationSockets/Channels/Traffic.cs
@@ -18,7 +18,7 @@ public class TrafficChannel : IWebsocketChannel
     public string Description => "Sends traffic data, includes all traffic vehicles and objects (TODO!).";
     public int Channel => 4;
     public WebSocketChannelType ChannelType => WebSocketChannelType.Continuous;
-    public JsonSerializerOptions JsonOptions => new JsonSerializerOptions
+    private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
     {
         NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals
     };


### PR DESCRIPTION
# Description
Made the JSON settings object build once instead of rebuilding it on every send. 
Speeds up traffic data sending.

## Type of change
Check the relavent options (place an "x" between the brackets)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
