### PR TITLE
Fix event bus thread safety and handler error

### DIFF
--- a/ETS2LA.Backend/EventBus/Bus.cs
+++ b/ETS2LA.Backend/EventBus/Bus.cs
@@ -12,31 +12,53 @@ namespace ETS2LA.Backend.Events
         public static Events Current => _instance.Value;
 
         private static readonly Dictionary<string, List<Delegate>> _subscribers = new();
+        private static readonly object _lock = new();
 
         public void Subscribe<T>(string topic, Action<T> handler)
         {
-            if (!_subscribers.ContainsKey(topic))
+            lock (_lock)
             {
-                _subscribers[topic] = new List<Delegate>();
+                if (!_subscribers.TryGetValue(topic, out var handlers))
+                {
+                    handlers = new List<Delegate>();
+                    _subscribers[topic] = handlers;
+                }
+                handlers.Add(handler);
             }
-            _subscribers[topic].Add(handler);
         }
 
         public void Unsubscribe<T>(string topic, Action<T> handler)
         {
-            if (_subscribers.ContainsKey(topic))
+            lock (_lock)
             {
-                _subscribers[topic].Remove(handler);
+                if (_subscribers.TryGetValue(topic, out var handlers))
+                {
+                    handlers.Remove(handler);
+                }
             }
         }
 
         public void Publish<T>(string topic, T data)
         {
-            if (_subscribers.ContainsKey(topic))
+            Delegate[] handlers;
+            lock (_lock)
+            {
+                if (!_subscribers.TryGetValue(topic, out var list) || list.Count == 0)
+                {
+                    return;
+                }
+                handlers = list.ToArray();
+            }
+
+            foreach (var handler in handlers)
             {
                 try
                 {
-                    foreach (var handler in _subscribers[topic])
+                    if (handler is Action<T> action)
+                    {
+                        action(data);
+                    }
+                    else
                     {
                         handler.DynamicInvoke(data);
                     }


### PR DESCRIPTION
# Description
- Added lock around subscriber access
- Handler errors no longer skip other subscribers
- Faster direct invoke instead of DynamicInvoke
- Lock statement the goat 🙏

## Type of change
Check the relavent options (place an "x" between the brackets)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
