### PR TITLE
Reuse telemetry memory mapped file instead of reopening every update

### DIFF
--- a/ETS2LA.Game/SDK/Camera.cs
+++ b/ETS2LA.Game/SDK/Camera.cs
@@ -47,15 +47,23 @@ public class CameraProvider
     private float UpdateRate { get; set; } = 1f / 60f;
     public string EventString = "ETS2LA.Game.SDK.Camera.Data";
 
-    private MemoryReader? _reader;
+    private MemoryReader _reader;
     private CameraData? _currentData = new();
 
     string mmapName = "Local\\ETS2LACameraProps";
     string mmapNameLinux = "/dev/shm/ETS2LACameraProps";
     int mmapSize = 128;
 
+    private MemoryMappedFile? _mmf;
+    private MemoryMappedViewAccessor? _accessor;
+    private byte[] _buffer = Array.Empty<byte>();
+    private readonly Stopwatch _sinceReconnect = Stopwatch.StartNew();
+
     public CameraProvider()
     {
+        _buffer = new byte[mmapSize];
+        _reader = new MemoryReader(_buffer);
+
         Thread updateThread = new Thread(UpdateThread)
         {
             IsBackground = true
@@ -94,6 +102,45 @@ public class CameraProvider
         }
     }
     
+    private bool TryOpenMemory()
+    {
+        if (_accessor != null)
+            return true;
+
+        try
+        {
+            #if WINDOWS
+                _mmf = MemoryMappedFile.OpenExisting(mmapName);
+            # else
+                _mmf = MemoryMappedFile.CreateFromFile(mmapNameLinux);
+            # endif
+
+            _accessor = _mmf.CreateViewAccessor(0, mmapSize, MemoryMappedFileAccess.Read);
+            return true;
+        }
+        catch (FileNotFoundException)
+        {
+            CloseMemory();
+            Thread.Sleep(10000);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            CloseMemory();
+            Logger.Error($"Error initializing memory mapped file: {ex.Message}");
+            Thread.Sleep(10000);
+            return false;
+        }
+    }
+
+    private void CloseMemory()
+    {
+        _accessor?.Dispose();
+        _accessor = null;
+        _mmf?.Dispose();
+        _mmf = null;
+    }
+
     private void Update()
     {
         if (_currentData == null)
@@ -101,41 +148,19 @@ public class CameraProvider
             _currentData = new CameraData();
         }
 
-        MemoryMappedFile? mmf = null;
-        MemoryMappedViewAccessor? accessor = null;
-        byte[] buffer = new byte[mmapSize];
+        if (!TryOpenMemory())
+            return;
 
         try
         {
-            #if WINDOWS
-                mmf = MemoryMappedFile.OpenExisting(mmapName);
-            # else
-                mmf = MemoryMappedFile.CreateFromFile(mmapNameLinux);
-            # endif
-
-            accessor = mmf.CreateViewAccessor(0, mmapSize, MemoryMappedFileAccess.Read);
-            accessor.ReadArray(0, buffer, 0, mmapSize);
-            _reader = new MemoryReader(buffer);
+            _accessor!.ReadArray(0, _buffer, 0, mmapSize);
         }
-        catch (FileNotFoundException)
+        catch (Exception)
         {
-            Thread.Sleep(10000);
-            _reader = null;
+            // Mapping went away (e.g. game closed), reconnect on the next update.
+            CloseMemory();
             return;
         }
-        catch (Exception ex)
-        {
-            Logger.Error($"Error initializing memory mapped file: {ex.Message}");
-            Thread.Sleep(10000);
-            _reader = null;
-            return;
-        }
-        finally
-        {
-            accessor?.Dispose();
-            mmf?.Dispose();
-        }
-
 
         int offset = 0;
         _currentData.fov = _reader.ReadFloat(offset); offset += 4;
@@ -174,5 +199,12 @@ public class CameraProvider
         ); offset += 16;
 
         Events.Current.Publish<CameraData>(EventString, _currentData);
+
+        // Periodically reopen the mmap to detect game restarts.
+        if (_sinceReconnect.Elapsed.TotalSeconds > 1.0)
+        {
+            CloseMemory();
+            _sinceReconnect.Restart();
+        }
     }
 }

--- a/ETS2LA.Game/SDK/Navigation.cs
+++ b/ETS2LA.Game/SDK/Navigation.cs
@@ -45,16 +45,24 @@ public class NavigationProvider
                                                  // once a second, it's not going to change much.
     public string EventString = "ETS2LA.Game.SDK.Navigation.Data";
 
-    private MemoryReader? _reader;
+    private MemoryReader _reader;
     private NavigationData? _currentData = new();
-    
+
 
     string mmapName = "Local\\ETS2LARoute";
     string mmapNameLinux = "/dev/shm/ETS2LARoute";
     int mmapSize = 96000;
 
+    private MemoryMappedFile? _mmf;
+    private MemoryMappedViewAccessor? _accessor;
+    private byte[] _buffer = Array.Empty<byte>();
+    private readonly Stopwatch _sinceReconnect = Stopwatch.StartNew();
+
     public NavigationProvider()
     {
+        _buffer = new byte[mmapSize];
+        _reader = new MemoryReader(_buffer);
+
         Thread updateThread = new Thread(UpdateThread)
         {
             IsBackground = true
@@ -85,6 +93,45 @@ public class NavigationProvider
         }
     }
     
+    private bool TryOpenMemory()
+    {
+        if (_accessor != null)
+            return true;
+
+        try
+        {
+            #if WINDOWS
+                _mmf = MemoryMappedFile.OpenExisting(mmapName);
+            # else
+                _mmf = MemoryMappedFile.CreateFromFile(mmapNameLinux);
+            # endif
+
+            _accessor = _mmf.CreateViewAccessor(0, mmapSize, MemoryMappedFileAccess.Read);
+            return true;
+        }
+        catch (FileNotFoundException)
+        {
+            CloseMemory();
+            Thread.Sleep(10000);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            CloseMemory();
+            Logger.Error($"Error initializing memory mapped file: {ex.Message}");
+            Thread.Sleep(10000);
+            return false;
+        }
+    }
+
+    private void CloseMemory()
+    {
+        _accessor?.Dispose();
+        _accessor = null;
+        _mmf?.Dispose();
+        _mmf = null;
+    }
+
     private void Update()
     {
         if (_currentData == null)
@@ -92,41 +139,19 @@ public class NavigationProvider
             _currentData = new NavigationData();
         }
 
-        MemoryMappedFile? mmf = null;
-        MemoryMappedViewAccessor? accessor = null;
-        byte[] buffer = new byte[mmapSize];
+        if (!TryOpenMemory())
+            return;
 
         try
         {
-            #if WINDOWS
-                mmf = MemoryMappedFile.OpenExisting(mmapName);
-            # else
-                mmf = MemoryMappedFile.CreateFromFile(mmapNameLinux);
-            # endif
-
-            accessor = mmf.CreateViewAccessor(0, mmapSize, MemoryMappedFileAccess.Read);
-            accessor.ReadArray(0, buffer, 0, mmapSize);
-            _reader = new MemoryReader(buffer);
+            _accessor!.ReadArray(0, _buffer, 0, mmapSize);
         }
-        catch (FileNotFoundException)
+        catch (Exception)
         {
-            Thread.Sleep(10000);
-            _reader = null;
+            // Mapping went away (e.g. game closed), reconnect on the next update.
+            CloseMemory();
             return;
         }
-        catch (Exception ex)
-        {
-            Logger.Error($"Error initializing memory mapped file: {ex.Message}");
-            Thread.Sleep(10000);
-            _reader = null;
-            return;
-        }
-        finally
-        {
-            accessor?.Dispose();
-            mmf?.Dispose();
-        }
-
 
         NavigationData data = new NavigationData();
         data.entries = new NavigationEntry[6000];
@@ -140,7 +165,14 @@ public class NavigationProvider
             data.entries[i] = entry;
         }
 
-        
+
         Events.Current.Publish<NavigationData>(EventString, data);
+
+        // Periodically reopen the mmap to detect game restarts.
+        if (_sinceReconnect.Elapsed.TotalSeconds > 1.0)
+        {
+            CloseMemory();
+            _sinceReconnect.Restart();
+        }
     }
 }

--- a/ETS2LA.Game/SDK/ParkedVehicles.cs
+++ b/ETS2LA.Game/SDK/ParkedVehicles.cs
@@ -27,15 +27,23 @@ public class ParkedVehiclesProvider
     private float UpdateRate { get; set; } = 1f / 60f;
     public string EventString = "ETS2LA.Game.SDK.ParkedVehicles.Data";
 
-    private MemoryReader? _reader;
+    private MemoryReader _reader;
     private ParkedVehicleData? _currentData;
 
     string mmapName = "Local\\ETS2LAParkedVehicles";
     string mmapNameLinux = "/dev/shm/ETS2LAParkedVehicles";
     int mmapSize = 1720;
 
+    private MemoryMappedFile? _mmf;
+    private MemoryMappedViewAccessor? _accessor;
+    private byte[] _buffer = Array.Empty<byte>();
+    private readonly Stopwatch _sinceReconnect = Stopwatch.StartNew();
+
     public ParkedVehiclesProvider()
     {
+        _buffer = new byte[mmapSize];
+        _reader = new MemoryReader(_buffer);
+
         Thread updateThread = new Thread(UpdateThread)
         {
             IsBackground = true
@@ -71,6 +79,45 @@ public class ParkedVehiclesProvider
         }
     }
     
+    private bool TryOpenMemory()
+    {
+        if (_accessor != null)
+            return true;
+
+        try
+        {
+            #if WINDOWS
+                _mmf = MemoryMappedFile.OpenExisting(mmapName);
+            # else
+                _mmf = MemoryMappedFile.CreateFromFile(mmapNameLinux);
+            # endif
+
+            _accessor = _mmf.CreateViewAccessor(0, mmapSize, MemoryMappedFileAccess.Read);
+            return true;
+        }
+        catch (FileNotFoundException)
+        {
+            CloseMemory();
+            Thread.Sleep(10000);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            CloseMemory();
+            Logger.Error($"Error initializing memory mapped file: {ex.Message}");
+            Thread.Sleep(10000);
+            return false;
+        }
+    }
+
+    private void CloseMemory()
+    {
+        _accessor?.Dispose();
+        _accessor = null;
+        _mmf?.Dispose();
+        _mmf = null;
+    }
+
     private void Update()
     {
         if (_currentData == null)
@@ -78,39 +125,18 @@ public class ParkedVehiclesProvider
             _currentData = new ParkedVehicleData{ vehicles = new List<ParkedVehicle>() };
         }
 
-        MemoryMappedFile? mmf = null;
-        MemoryMappedViewAccessor? accessor = null;
-        byte[] buffer = new byte[mmapSize];
+        if (!TryOpenMemory())
+            return;
 
         try
         {
-            #if WINDOWS
-                mmf = MemoryMappedFile.OpenExisting(mmapName);
-            # else
-                mmf = MemoryMappedFile.CreateFromFile(mmapNameLinux);
-            # endif
-
-            accessor = mmf.CreateViewAccessor(0, mmapSize, MemoryMappedFileAccess.Read);
-            accessor.ReadArray(0, buffer, 0, mmapSize);
-            _reader = new MemoryReader(buffer);
+            _accessor!.ReadArray(0, _buffer, 0, mmapSize);
         }
-        catch (FileNotFoundException)
+        catch (Exception)
         {
-            Thread.Sleep(10000);
-            _reader = null;
+            // Mapping went away (e.g. game closed), reconnect on the next update.
+            CloseMemory();
             return;
-        }
-        catch (Exception ex)
-        {
-            Logger.Error($"Error initializing memory mapped file: {ex.Message}");
-            Thread.Sleep(10000);
-            _reader = null;
-            return;
-        }
-        finally
-        {
-            accessor?.Dispose();
-            mmf?.Dispose();
         }
 
         List<ParkedVehicle> vehicles = new List<ParkedVehicle>();
@@ -142,5 +168,12 @@ public class ParkedVehiclesProvider
 
         _currentData.vehicles = vehicles;
         Events.Current.Publish<ParkedVehicleData>(EventString, _currentData);
+
+        // Periodically reopen the mmap to detect game restarts.
+        if (_sinceReconnect.Elapsed.TotalSeconds > 1.0)
+        {
+            CloseMemory();
+            _sinceReconnect.Restart();
+        }
     }
 }

--- a/ETS2LA.Game/SDK/Semaphores.cs
+++ b/ETS2LA.Game/SDK/Semaphores.cs
@@ -94,16 +94,24 @@ public class SemaphoreProvider
     private float UpdateRate { get; set; } = 1f / 60f;
     public string EventString = "ETS2LA.Game.SDK.Semaphore.Data";
 
-    private MemoryReader? _reader;
+    private MemoryReader _reader;
     private SemaphoreData? _currentData = new();
-    
+
 
     string mmapName = "Local\\ETS2LASemaphore";
     string mmapNameLinux = "/dev/shm/ETS2LASemaphore";
     int mmapSize = 1920;
 
+    private MemoryMappedFile? _mmf;
+    private MemoryMappedViewAccessor? _accessor;
+    private byte[] _buffer = Array.Empty<byte>();
+    private readonly Stopwatch _sinceReconnect = Stopwatch.StartNew();
+
     public SemaphoreProvider()
     {
+        _buffer = new byte[mmapSize];
+        _reader = new MemoryReader(_buffer);
+
         Thread updateThread = new Thread(UpdateThread)
         {
             IsBackground = true
@@ -139,6 +147,45 @@ public class SemaphoreProvider
         }
     }
     
+    private bool TryOpenMemory()
+    {
+        if (_accessor != null)
+            return true;
+
+        try
+        {
+            #if WINDOWS
+                _mmf = MemoryMappedFile.OpenExisting(mmapName);
+            # else
+                _mmf = MemoryMappedFile.CreateFromFile(mmapNameLinux);
+            # endif
+
+            _accessor = _mmf.CreateViewAccessor(0, mmapSize, MemoryMappedFileAccess.Read);
+            return true;
+        }
+        catch (FileNotFoundException)
+        {
+            CloseMemory();
+            Thread.Sleep(10000);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            CloseMemory();
+            Logger.Error($"Error initializing memory mapped file: {ex.Message}");
+            Thread.Sleep(10000);
+            return false;
+        }
+    }
+
+    private void CloseMemory()
+    {
+        _accessor?.Dispose();
+        _accessor = null;
+        _mmf?.Dispose();
+        _mmf = null;
+    }
+
     private void Update()
     {
         if (_currentData == null)
@@ -146,39 +193,18 @@ public class SemaphoreProvider
             _currentData = new SemaphoreData();
         }
 
-        MemoryMappedFile? mmf = null;
-        MemoryMappedViewAccessor? accessor = null;
-        byte[] buffer = new byte[mmapSize];
+        if (!TryOpenMemory())
+            return;
 
         try
         {
-            #if WINDOWS
-                mmf = MemoryMappedFile.OpenExisting(mmapName);
-            # else
-                mmf = MemoryMappedFile.CreateFromFile(mmapNameLinux);
-            # endif
-
-            accessor = mmf.CreateViewAccessor(0, mmapSize, MemoryMappedFileAccess.Read);
-            accessor.ReadArray(0, buffer, 0, mmapSize);
-            _reader = new MemoryReader(buffer);
+            _accessor!.ReadArray(0, _buffer, 0, mmapSize);
         }
-        catch (FileNotFoundException)
+        catch (Exception)
         {
-            Thread.Sleep(10000);
-            _reader = null;
+            // Mapping went away (e.g. game closed), reconnect on the next update.
+            CloseMemory();
             return;
-        }
-        catch (Exception ex)
-        {
-            Logger.Error($"Error initializing memory mapped file: {ex.Message}");
-            Thread.Sleep(10000);
-            _reader = null;
-            return;
-        }
-        finally
-        {
-            accessor?.Dispose();
-            mmf?.Dispose();
         }
 
         List<Semaphore> semaphores = new List<Semaphore>();
@@ -211,7 +237,14 @@ public class SemaphoreProvider
         }
 
         _currentData.semaphores = semaphores.ToArray();
-        
+
         Events.Current.Publish<SemaphoreData>(EventString, _currentData);
+
+        // Periodically reopen the mmap to detect game restarts.
+        if (_sinceReconnect.Elapsed.TotalSeconds > 1.0)
+        {
+            CloseMemory();
+            _sinceReconnect.Restart();
+        }
     }
 }

--- a/ETS2LA.Game/SDK/Traffic.cs
+++ b/ETS2LA.Game/SDK/Traffic.cs
@@ -69,16 +69,24 @@ public class TrafficProvider
     private float UpdateRate { get; set; } = 1f / 60f;
     public string EventString = "ETS2LA.Game.SDK.Traffic.Data";
 
-    private MemoryReader? _reader;
+    private MemoryReader _reader;
     private TrafficData? _currentData = new();
-    
+
 
     string mmapName = "Local\\ETS2LATraffic";
     string mmapNameLinux = "/dev/shm/ETS2LATraffic";
     int mmapSize = 6800;
 
+    private MemoryMappedFile? _mmf;
+    private MemoryMappedViewAccessor? _accessor;
+    private byte[] _buffer = Array.Empty<byte>();
+    private readonly Stopwatch _sinceReconnect = Stopwatch.StartNew();
+
     public TrafficProvider()
     {
+        _buffer = new byte[mmapSize];
+        _reader = new MemoryReader(_buffer);
+
         Thread updateThread = new Thread(UpdateThread)
         {
             IsBackground = true
@@ -114,6 +122,45 @@ public class TrafficProvider
         }
     }
     
+    private bool TryOpenMemory()
+    {
+        if (_accessor != null)
+            return true;
+
+        try
+        {
+            #if WINDOWS
+                _mmf = MemoryMappedFile.OpenExisting(mmapName);
+            # else
+                _mmf = MemoryMappedFile.CreateFromFile(mmapNameLinux);
+            # endif
+
+            _accessor = _mmf.CreateViewAccessor(0, mmapSize, MemoryMappedFileAccess.Read);
+            return true;
+        }
+        catch (FileNotFoundException)
+        {
+            CloseMemory();
+            Thread.Sleep(10000);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            CloseMemory();
+            Logger.Error($"Error initializing memory mapped file: {ex.Message}");
+            Thread.Sleep(10000);
+            return false;
+        }
+    }
+
+    private void CloseMemory()
+    {
+        _accessor?.Dispose();
+        _accessor = null;
+        _mmf?.Dispose();
+        _mmf = null;
+    }
+
     private void Update()
     {
         if (_currentData == null)
@@ -121,41 +168,19 @@ public class TrafficProvider
             _currentData = new TrafficData();
         }
 
-        MemoryMappedFile? mmf = null;
-        MemoryMappedViewAccessor? accessor = null;
-        byte[] buffer = new byte[mmapSize];
+        if (!TryOpenMemory())
+            return;
 
         try
         {
-            #if WINDOWS
-                mmf = MemoryMappedFile.OpenExisting(mmapName);
-            # else
-                mmf = MemoryMappedFile.CreateFromFile(mmapNameLinux);
-            # endif
-
-            accessor = mmf.CreateViewAccessor(0, mmapSize, MemoryMappedFileAccess.Read);
-            accessor.ReadArray(0, buffer, 0, mmapSize);
-            _reader = new MemoryReader(buffer);
+            _accessor!.ReadArray(0, _buffer, 0, mmapSize);
         }
-        catch (FileNotFoundException)
+        catch (Exception)
         {
-            Thread.Sleep(10000);
-            _reader = null;
+            // Mapping went away (e.g. game closed), reconnect on the next update.
+            CloseMemory();
             return;
         }
-        catch (Exception ex)
-        {
-            Logger.Error($"Error initializing memory mapped file: {ex.Message}");
-            Thread.Sleep(10000);
-            _reader = null;
-            return;
-        }
-        finally
-        {
-            accessor?.Dispose();
-            mmf?.Dispose();
-        }
-
 
         List<TrafficVehicle> vehicles = new List<TrafficVehicle>();
         int offset = 0;
@@ -235,5 +260,12 @@ public class TrafficProvider
 
         _currentData.vehicles = vehicles.ToArray();
         Events.Current.Publish<TrafficData>(EventString, _currentData);
+
+        // Periodically reopen the mmap to detect game restarts.
+        if (_sinceReconnect.Elapsed.TotalSeconds > 1.0)
+        {
+            CloseMemory();
+            _sinceReconnect.Restart();
+        }
     }
 }

--- a/ETS2LA.Telemetry/Program.cs
+++ b/ETS2LA.Telemetry/Program.cs
@@ -25,16 +25,21 @@ public class GameTelemetry
 
     public string EventString = "ETS2LA.Telemetry.Data";
     
-    private MemoryReader? _reader;
+    private MemoryReader _reader;
     private GameTelemetryData? _currentData = new();
     private bool shutdown = false;
-    
+
 
     string mmapName = "Local\\SCSTelemetry";
     string mmapNameLinux = "/dev/shm/SCSTelemetry";
 
     int mmapSize = 32 * 1024;
     int stringSize = 64;
+
+    private MemoryMappedFile? _mmf;
+    private MemoryMappedViewAccessor? _accessor;
+    private byte[] _buffer = Array.Empty<byte>();
+    private readonly Stopwatch _sinceReconnect = Stopwatch.StartNew();
     
     Dictionary<int, string> intToDays = new Dictionary<int, string>
     {
@@ -77,6 +82,9 @@ public class GameTelemetry
 
     public GameTelemetry()
     {
+        _buffer = new byte[mmapSize];
+        _reader = new MemoryReader(_buffer);
+
         Thread updateThread = new Thread(UpdateThread)
         {
             IsBackground = true
@@ -113,32 +121,29 @@ public class GameTelemetry
                 Logger.Error(ex.ToString(), "Error in telemetry update loop.");
             }
         }
+
+        CloseMemory();
     }
 
-    private void Update()
+    private bool TryOpenMemory()
     {
-        if (_currentData == null)
-            _currentData = new();
-        
-        MemoryMappedFile? mmf = null;
-        MemoryMappedViewAccessor? accessor = null;
-        byte[] buffer = new byte[mmapSize];
+        if (_accessor != null)
+            return true;
 
         try
         {
             #if WINDOWS
-                mmf = MemoryMappedFile.OpenExisting(mmapName);
+                _mmf = MemoryMappedFile.OpenExisting(mmapName);
             # else
-                mmf = MemoryMappedFile.CreateFromFile(mmapNameLinux);
+                _mmf = MemoryMappedFile.CreateFromFile(mmapNameLinux);
             # endif
-            
-            accessor = mmf.CreateViewAccessor(0, mmapSize, MemoryMappedFileAccess.Read);
-            accessor.ReadArray(0, buffer, 0, mmapSize);
-            _reader = new MemoryReader(buffer);
+
+            _accessor = _mmf.CreateViewAccessor(0, mmapSize, MemoryMappedFileAccess.Read);
+            return true;
         }
         catch (FileNotFoundException)
         {
-            _currentData.sdkActive = false;
+            CloseMemory();
             NotificationHandler.Current.SendNotification(new Notification
             {
                 Id = "GameTelemetry.MMFNotFound",
@@ -147,24 +152,43 @@ public class GameTelemetry
                 IsProgressIndeterminate = true,
             });
             Thread.Sleep(1000);
-            _reader = null;
-            return;
+            return false;
         }
         catch (Exception)
         {
+            CloseMemory();
             Thread.Sleep(1000);
-            _reader = null;
+            return false;
+        }
+    }
+
+    private void CloseMemory()
+    {
+        _accessor?.Dispose();
+        _accessor = null;
+        _mmf?.Dispose();
+        _mmf = null;
+    }
+
+    private void Update()
+    {
+        if (_currentData == null)
+            _currentData = new();
+
+        if (!TryOpenMemory())
+        {
+            _currentData.sdkActive = false;
             return;
         }
-        finally
-        {
-            accessor?.Dispose();
-            mmf?.Dispose();
-        }
 
-        if (_reader == null)
+        try
         {
-            Logging.Logger.Debug("Memory reader is null, skipping telemetry read.");
+            _accessor!.ReadArray(0, _buffer, 0, mmapSize);
+        }
+        catch (Exception)
+        {
+            // Mapping went away (e.g. game closed), reconnect on the next update.
+            CloseMemory();
             return;
         }
 
@@ -187,7 +211,7 @@ public class GameTelemetry
         _currentData.scsValues.telemetryPluginRevision = _reader.ReadInt(offset); offset += 4;
         _currentData.scsValues.versionMajor = _reader.ReadInt(offset); offset += 4;
         _currentData.scsValues.versionMinor = _reader.ReadInt(offset); offset += 4;
-        _currentData.scsValues.game = ReadGame(offset, buffer); offset += 4;
+        _currentData.scsValues.game = ReadGame(offset, _buffer); offset += 4;
         _currentData.scsValues.telemetryVersionGameMajor = _reader.ReadInt(offset); offset += 4;
         _currentData.scsValues.telemetryVersionGameMinor = _reader.ReadInt(offset); offset += 4;
 
@@ -506,6 +530,13 @@ public class GameTelemetry
 
         // Publish to the event bus
         Events.Current.Publish<GameTelemetryData>(EventString, _currentData);
+
+        // Periodically reopen the mmap to detect game restarts.
+        if (_sinceReconnect.Elapsed.TotalSeconds > 1.0)
+        {
+            CloseMemory();
+            _sinceReconnect.Restart();
+        }
     }
 
     public void Shutdown()


### PR DESCRIPTION
# Description
The telemetry mmap and read buffer are now opened once and reused instead of being recreated on every 60Hz update. The mmap is still revalidated once per second so game shutdowns and restarts are detected like before. 
Also removes a dead null check on the memory reader. 
Tested on Linux only cuz not home rn to check on Spydows :c

## Type of change
Check the relavent options (place an "x" between the brackets)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
