### PR TITLE
Resolve Steam installs by app ID instead of folder name

### DIFF
--- a/ETS2LA.Game/Program.cs
+++ b/ETS2LA.Game/Program.cs
@@ -40,17 +40,17 @@ public class GameHandler
 
     private void PopulateInstallations()
     {
-        List<string> games = SteamHandler.FindGamesInLibraries(new List<string>
+        Dictionary<string, string> games = SteamHandler.FindGamesInLibraries(new List<string>
         {
-            "Euro Truck Simulator 2",
-            "American Truck Simulator"
+            SteamHandler.EuroTruckSimulator2AppId,
+            SteamHandler.AmericanTruckSimulatorAppId
         });
 
         Logger.Info($"Found {games.Count} game installations.");
-        games.ForEach(gamePath =>
+        foreach ((string appId, string gamePath) in games)
         {
-            GameType type = gamePath.EndsWith("Euro Truck Simulator 2") 
-                            ? GameType.EuroTruckSimulator2 
+            GameType type = appId == SteamHandler.EuroTruckSimulator2AppId
+                            ? GameType.EuroTruckSimulator2
                             : GameType.AmericanTruckSimulator;
 
             string executablePath = Path.Combine(
@@ -90,6 +90,6 @@ public class GameHandler
             });
 
             Installation installation = Installations[^1];
-        });
+        }
     }
 }

--- a/ETS2LA.Game/Steam/Steam.cs
+++ b/ETS2LA.Game/Steam/Steam.cs
@@ -4,7 +4,17 @@ using Microsoft.Win32;
 
 namespace ETS2LA.Game.Steam;
 
-// TODO: Switch from names to IDs. Those are stored in libraryfolders.vdf directly.
+/// <summary>
+///  Represents a single Steam library folder as listed in libraryfolders.vdf.
+/// </summary>
+public class SteamLibrary
+{
+    /// <summary>Root path of the library (the folder that contains steamapps).</summary>
+    public required string Path { get; set; }
+
+    /// <summary>App IDs of the games installed in this library.</summary>
+    public List<string> AppIds { get; set; } = new();
+}
 
 /// <summary>
 ///  This class is used by ETS2LA to discover and manage Steam library folders.
@@ -12,6 +22,12 @@ namespace ETS2LA.Game.Steam;
 /// </summary>
 class SteamHandler
 {
+    /// <summary>Steam app ID of Euro Truck Simulator 2.</summary>
+    public const string EuroTruckSimulator2AppId = "227300";
+
+    /// <summary>Steam app ID of American Truck Simulator.</summary>
+    public const string AmericanTruckSimulatorAppId = "270880";
+
     /// <summary>
     ///  Gets the path of the current libraryfolders.vdf file.
     ///  This file includes information about where Steam games are installed.
@@ -28,60 +44,102 @@ class SteamHandler
     }
 
     /// <summary>
-    ///  Gets a list of all current steam library folders.
+    ///  Parses libraryfolders.vdf into a list of Steam libraries. Each library
+    ///  holds its root path and the app IDs of the games installed in it.
     ///  This includes both default and user added libraries.
     /// </summary>
-    /// <returns>Libraries as a string List.</returns>
-    public static List<string> GetLibraryFolders()
+    /// <returns>All configured Steam libraries.</returns>
+    public static List<SteamLibrary> GetLibraries()
     {
         string vdfPath = GetLibraryVdfPath();
+        List<SteamLibrary> libraries = new();
         if (!File.Exists(vdfPath))
-            return new List<string>();
+            return libraries;
 
-        List<string> libraryFolders = new();
-        foreach (string line in File.ReadAllLines(vdfPath))
+        SteamLibrary? current = null;
+        bool inAppsBlock = false;
+        foreach (string rawLine in File.ReadAllLines(vdfPath))
         {
-            # if WINDOWS
-                if (line.Trim().StartsWith("\"") && line.Contains("\"path\""))
-                {
-                    string path = line.Split('"')[3];
-                    libraryFolders.Add(Path.Combine(path, "steamapps", "common"));
-                }
-            # else
-                if (line.Contains("\"path\""))
-                {
-                    string path = line.Split('"')[3];
-                    libraryFolders.Add(Path.Combine(path, "steamapps", "common"));
-                }
-            #endif
+            string line = rawLine.Trim();
+
+            // The "path" key marks the start of a new library entry.
+            if (line.StartsWith("\"path\""))
+            {
+                current = new SteamLibrary { Path = line.Split('"')[3] };
+                libraries.Add(current);
+                inAppsBlock = false;
+            }
+            // The "apps" key opens a block listing the installed app IDs.
+            else if (line.StartsWith("\"apps\""))
+            {
+                inAppsBlock = true;
+            }
+            else if (inAppsBlock)
+            {
+                // Entries look like:  "227300"   "12345678"  where the key is the
+                // app ID and the value is its size on disk. The block ends with "}".
+                if (line.StartsWith("}"))
+                    inAppsBlock = false;
+                else if (line.StartsWith("\"") && current != null)
+                    current.AppIds.Add(line.Split('"')[1]);
+            }
         }
 
-        return libraryFolders;
+        return libraries;
     }
 
     /// <summary>
-    ///  Finds the specified games in all library folders. Game names
-    ///  should be the names of the game folder.
+    ///  Finds the specified games across all Steam libraries by their app IDs.
+    ///  An app ID is only resolved if libraryfolders.vdf reports it as installed
+    ///  and its install folder actually exists on disk.
     /// </summary>
-    /// <param name="gameNames">List of games to search for.</param>
-    /// <returns>List of found game paths.</returns>
-    public static List<string> FindGamesInLibraries(List<string> gameNames)
+    /// <param name="appIds">Steam app IDs to search for.</param>
+    /// <returns>Map of found app IDs to their install paths.</returns>
+    public static Dictionary<string, string> FindGamesInLibraries(List<string> appIds)
     {
-        List<string> foundGames = new();
-        List<string> libraryFolders = GetLibraryFolders();
+        Dictionary<string, string> foundGames = new();
 
-        foreach (string library in libraryFolders)
+        foreach (SteamLibrary library in GetLibraries())
         {
-            foreach (string gameName in gameNames)
+            string steamApps = Path.Combine(library.Path, "steamapps");
+            foreach (string appId in appIds)
             {
-                string gamePath = Path.Combine(library, gameName);
+                if (foundGames.ContainsKey(appId) || !library.AppIds.Contains(appId))
+                    continue;
+
+                string? installDir = GetInstallDir(steamApps, appId);
+                if (installDir == null)
+                    continue;
+
+                string gamePath = Path.Combine(steamApps, "common", installDir);
                 if (Directory.Exists(gamePath))
-                {
-                    foundGames.Add(gamePath);
-                }
+                    foundGames[appId] = gamePath;
             }
         }
 
         return foundGames;
+    }
+
+    /// <summary>
+    ///  Reads the install folder name of an app from its appmanifest_{appId}.acf
+    ///  file. This is the name of the game's folder inside steamapps/common.
+    /// </summary>
+    /// <param name="steamAppsPath">Path to the library's steamapps folder.</param>
+    /// <param name="appId">Steam app ID to look up.</param>
+    /// <returns>The install folder name, or null if it can't be determined.</returns>
+    private static string? GetInstallDir(string steamAppsPath, string appId)
+    {
+        string manifestPath = Path.Combine(steamAppsPath, $"appmanifest_{appId}.acf");
+        if (!File.Exists(manifestPath))
+            return null;
+
+        foreach (string rawLine in File.ReadAllLines(manifestPath))
+        {
+            string line = rawLine.Trim();
+            if (line.StartsWith("\"installdir\""))
+                return line.Split('"')[3];
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
# Description
This completes the TODO in Steam.cs (Switch from names to IDs)
Steam games are now found by their app ID (ETS2: 227300, ATS: 270880) read from libraryfolders.vdf, and the install folder comes from the appmanifest .acf file.

## Type of change
Check the relavent options (place an "x" between the brackets)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
