### PR TITLE
Fix audio resource leak and broken loop condition

### DIFF
--- a/ETS2LA.Audio/AudioHandler.cs
+++ b/ETS2LA.Audio/AudioHandler.cs
@@ -108,8 +108,7 @@ public class AudioHandler
             {
                 if (job.LoopCondition != null)
                 {
-                    var conditionMet = job.LoopCondition.Invoke();
-                    while (conditionMet && !_currentCts.Token.IsCancellationRequested)
+                    while (job.LoopCondition.Invoke() && !_currentCts.Token.IsCancellationRequested)
                     {
                         await PlaySound(job, _currentCts.Token);
                     }
@@ -140,21 +139,28 @@ public class AudioHandler
         if (token.IsCancellationRequested) return;
         Logger.Info($"Playing sound: {job.Filename}");
 
-        var dataProvider = new AssetDataProvider(engine, format, File.OpenRead(job.Filename));
-        var player = new SoundPlayer(engine, format, dataProvider);
+        using var stream = File.OpenRead(job.Filename);
+        using var dataProvider = new AssetDataProvider(engine, format, stream);
+        using var player = new SoundPlayer(engine, format, dataProvider);
 
         outputDevice.MasterMixer.AddComponent(player);
-        outputDevice.Start();
-
-        player.Volume = _settings.Volume;
-        player.Play();
-
-        while (!token.IsCancellationRequested && player.State == PlaybackState.Playing)
+        try
         {
-            await Task.Delay(100, token);
-        }
+            outputDevice.Start();
 
-        outputDevice.Stop();
+            player.Volume = _settings.Volume;
+            player.Play();
+
+            while (!token.IsCancellationRequested && player.State == PlaybackState.Playing)
+            {
+                await Task.Delay(100, token);
+            }
+        }
+        finally
+        {
+            outputDevice.Stop();
+            outputDevice.MasterMixer.RemoveComponent(player);
+        }
     }
 
     private void OnSettingsChanged(AudioSettings audioSettings)


### PR DESCRIPTION
# Description
Two fixes:
  - PlaySound was leaking on every sound. It added the SoundPlayer to the mixer and opened the file stream but never
  cleaned either up, so they just piled up the longer ETS2LA ran. Now it disposes the player, data provider and stream and pulls the player back off the mixer after each sound (inside a "finally" so it also cleans up when playback gets cancelled).

  - The Queue overload that takes a Func<bool> only checked the condition once before the loop, so if it started out true
  it looped forever. Now it re-checks every iteration.

## Type of change
Check the relavent options (place an "x" between the brackets)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
