### PR TITLE
Add a audible feedback sound when changing audio volume.

### DIFF
--- a/ETS2LA.UI/Views/Settings/AudioSettings.axaml
+++ b/ETS2LA.UI/Views/Settings/AudioSettings.axaml
@@ -9,7 +9,7 @@
                 <TextBlock Text="Audio Volume" />
                 <TextBlock Text="{Binding ElementName=VolumeSlider, Path=Value, StringFormat='{}{0:0}%'}" />
             </StackPanel>
-            <Slider Name="VolumeSlider" Minimum="0" Maximum="100" ValueChanged="OnVolumeChanged" AutomationProperties.Name="Current volume" />
+            <Slider Name="VolumeSlider" Minimum="0" Maximum="100" ValueChanged="OnVolumeChanged" AutomationProperties.Name="Current volume"/>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/ETS2LA.UI/Views/Settings/AudioSettings.axaml.cs
+++ b/ETS2LA.UI/Views/Settings/AudioSettings.axaml.cs
@@ -1,11 +1,15 @@
 using ETS2LA.Audio;
 using Avalonia.Controls;
+using System.IO;
+using System.Threading.Tasks;
 
 namespace ETS2LA.UI.Views.Settings;
 
 public partial class AudioSettings : UserControl
 {
     private AudioHandler _audioHandler;
+    private bool _soundPlaying = false;
+    private bool _skipFirstPlay = true;
 
     public AudioSettings()
     {
@@ -14,9 +18,29 @@ public partial class AudioSettings : UserControl
         VolumeSlider.Value = _audioHandler.GetVolume() * 100.0;
     }
 
-    private void OnVolumeChanged(object? sender, Avalonia.Controls.Primitives.RangeBaseValueChangedEventArgs e)
+    private async void OnVolumeChanged(object? sender, Avalonia.Controls.Primitives.RangeBaseValueChangedEventArgs e)
     {
         float volume = (float)(e.NewValue / 100.0);
         _audioHandler.SetVolume(volume);
+
+        if (_skipFirstPlay)
+        {
+            _skipFirstPlay = false;
+            return;
+        }
+
+        if (_soundPlaying)
+            return;
+
+        _soundPlaying = true;
+
+        var engageSound = Path.Combine(AppContext.BaseDirectory, "Assets", "Sounds", "engage.mp3");
+        if (File.Exists(engageSound))
+        {
+            _audioHandler.Queue(engageSound, overrideCurrent: true);
+        }
+
+        await Task.Delay(1500);
+        _soundPlaying = false;
     }
 }


### PR DESCRIPTION
# Description
Add an audible feedback sound when changing audio, with a 1.5 second delay to prevent spamming of the console, and sound. 
This uses the engagement sound, as it fits the best as feedback. This also uses ETS2LA.Audio, natively.

## Type of change
- [ x] New feature (non-breaking change which adds functionality)
