### PR TITLE
Reset IsGameRunning when the SDK reports inactive

### DIFF
--- a/ETS2LA.State/Program.cs
+++ b/ETS2LA.State/Program.cs
@@ -81,6 +81,10 @@ public class ApplicationState
                 // This function will run until game data is successfully parsed.
                 parsingTask = WaitForParseSuccessful();
         }
+        else
+        {
+            IsGameRunning = false;
+        }
     }
 
     public void Shutdown()


### PR DESCRIPTION
ApplicationState.IsGameRunning was set to true on the first active telemetry update but never set back to false

I forgot about that xdd