### PR TITLE
Run plugin tick loops on dedicated threads and route tick errors through the logger

### DIFF
--- a/ETS2LA.Shared/ETS2LA.Shared.csproj
+++ b/ETS2LA.Shared/ETS2LA.Shared.csproj
@@ -10,4 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Huskui.Avalonia" Version="1.1.3" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ETS2LA.Logging\ETS2LA.Logging.csproj" />
+  </ItemGroup>
 </Project>

--- a/ETS2LA.Shared/Shared.cs
+++ b/ETS2LA.Shared/Shared.cs
@@ -1,5 +1,6 @@
 ﻿using Huskui.Avalonia.Controls;
 using Huskui.Avalonia.Models;
+using ETS2LA.Logging;
 using System.Numerics;
 
 namespace ETS2LA.Shared;
@@ -95,7 +96,7 @@ public abstract class Plugin : IPlugin
     public virtual void OnEnable()
     {
         _IsRunning = true;
-        Task.Run(() => RunningThread());
+        Task.Factory.StartNew(RunningThread, TaskCreationOptions.LongRunning);
     }
 
     /// <summary>
@@ -113,10 +114,10 @@ public abstract class Plugin : IPlugin
             interval = 1000.0 / TickRate;
 
             next += interval;
-            try { Tick(); } 
+            try { Tick(); }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error in plugin {Info.Name} Tick: {ex}");
+                Logger.Error($"Error in plugin {Info.Name} Tick: {ex}");
             }
 
             if (next < sw.Elapsed.TotalMilliseconds)


### PR DESCRIPTION
- Fixes plugin tick loops permanently occupying thread pool workers (now run on dedicated threads by change to TaskCreationOptions.LongRunning)
- Fixes plugin tick errors spamming a full stack trace every tick (now logged once with repeat collapsing)
- Routes tick errors through the logger instead of raw console output