### PR TITLE
Run remaining infinite loops on dedicated threads

### DIFF
--- a/ETS2LA.Controls/Linux/SDL3ControlsBackend.cs
+++ b/ETS2LA.Controls/Linux/SDL3ControlsBackend.cs
@@ -49,7 +49,7 @@ public class SDL3ControlsBackend : IControlsBackend
             else
             {
                 BootstrapConnectedJoysticks();
-                _listenerTask = Task.Run(ControlListener, _cts.Token);
+                _listenerTask = Task.Factory.StartNew(ControlListener, _cts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
             }
         }
         catch (Exception ex)

--- a/ETS2LA.Controls/Windows/SharpDXControlsBackend.cs
+++ b/ETS2LA.Controls/Windows/SharpDXControlsBackend.cs
@@ -37,7 +37,7 @@ public class SharpDXControlsBackend : IControlsBackend
 
         RefreshConnectedJoysticks();
 
-        Task.Run(() => ControlListener());
+        Task.Factory.StartNew(ControlListener, TaskCreationOptions.LongRunning);
         RegisterControl(DefaultControls.Assist);
         RegisterControl(DefaultControls.SET);
         RegisterControl(DefaultControls.Next);

--- a/ETS2LA.Game/Output/Output.cs
+++ b/ETS2LA.Game/Output/Output.cs
@@ -67,7 +67,7 @@ public class GameOutput
         TryOpenMemory();
         // Then we start listening to events and spin up the update thread.
         Events.Current.Subscribe<ControlEvent>(EventString, OnControlEvent);
-        Task.Run(Tick);
+        Task.Factory.StartNew(Tick, TaskCreationOptions.LongRunning);
     }
 
     private void TryOpenMemory()

--- a/ETS2LA.Overlay/Overlay.cs
+++ b/ETS2LA.Overlay/Overlay.cs
@@ -76,7 +76,7 @@ public class OverlayHandler
         overlaySettings = OverlaySettingsHandler.Current.GetSettings();
         OverlaySettingsHandler.Current.OnSettingsUpdated += OnOverlaySettingsUpdated;
 
-        Task.Run(() => RenderLoop());
+        Task.Factory.StartNew(RenderLoop, TaskCreationOptions.LongRunning);
         
         windows.Add(new ConsoleWindow());
         windows.Add(new OverlayInfoWindow());

--- a/ETS2LA.UI/Notifications/Notifications.cs
+++ b/ETS2LA.UI/Notifications/Notifications.cs
@@ -28,7 +28,7 @@ public class UINotificationHandler
 
     public UINotificationHandler()
     {
-        Task.Run(WatcherThread);
+        Task.Factory.StartNew(WatcherThread, TaskCreationOptions.LongRunning);
         NotificationHandler.Current.OnNotificationAdded += (sender, notification) =>
         {
             SendNotification(new UINotification

--- a/ETS2LA/Program.cs
+++ b/ETS2LA/Program.cs
@@ -70,14 +70,14 @@ internal static class Program
             .Build();
 
         bool shutdown = false;
-        var AnalyticsThread = Task.Run(() =>
+        var AnalyticsThread = Task.Factory.StartNew(() =>
         {
             while (!shutdown)
             {
                 AppAnalytics.Pulse();
                 Thread.Sleep(TimeSpan.FromMinutes(1));
             }
-        });
+        }, TaskCreationOptions.LongRunning);
 
         var BackendThread = Task.Run(() =>
         {


### PR DESCRIPTION
The remaining code that was stealing from .NET shared thread pool
Give them all dedicated threads instead to prevent performance issues