### PR TITLE
Add automatic game version and SDK detection on Linux

### DIFF
--- a/ETS2LA.Game/Installation.cs
+++ b/ETS2LA.Game/Installation.cs
@@ -34,6 +34,8 @@ public class Installation
 
     public string Version { get; set; } = "Undetermined";
 
+    public bool IsManuallyAdded { get; set; } = false;
+
     public bool IsParsed { get; set; } = false;
     public bool IsParsing { get; set; } = false;
     

--- a/ETS2LA.Game/Program.cs
+++ b/ETS2LA.Game/Program.cs
@@ -12,6 +12,11 @@ using ETS2LA.Game.Steam;
 using ETS2LA.Game.Output;
 using ETS2LA.Shared;
 
+using TruckLib.HashFs;
+
+using System.Text;
+using System.Text.RegularExpressions;
+
 
 namespace ETS2LA.Game;
 
@@ -20,7 +25,9 @@ public class GameHandler
     private static readonly Lazy<GameHandler> _instance = new(() => new GameHandler());
     public static GameHandler Current => _instance.Value;
     
-    public List<Installation> Installations { get; } = new();
+    // Copy the list whenever its modified so other threads can
+    // enum without crashes
+    public List<Installation> Installations { get; private set; } = new();
 
     public GameHandler()
     {
@@ -53,58 +60,196 @@ public class GameHandler
                             ? GameType.EuroTruckSimulator2
                             : GameType.AmericanTruckSimulator;
 
-            string executablePath = Path.Combine(
-                # if WINDOWS
-                    gamePath, 
-                    "bin", 
-                    "win_x64", 
-                    type == GameType.EuroTruckSimulator2 ? "eurotrucks2.exe" 
-                                                         : "amtrucks.exe"
-                # else
-                    gamePath, 
-                    "bin", 
-                    "linux_x64", 
-                    type == GameType.EuroTruckSimulator2 ? "eurotrucks2" 
-                                                         : "amtrucks"
-                # endif
-            );
-
-            string gameName = type == GameType.EuroTruckSimulator2 ? "Euro Truck Simulator 2" 
-                                                                   : "American Truck Simulator";
-            string documentsPath = Path.Combine(
-                #if WINDOWS
-                    Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), 
-                    gameName
-                #else
-                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                    ".local", "share", gameName
-                #endif
-            );
-
-            string version = "Unknown";
-            # if WINDOWS
-                try
-                {
-                    FileVersionInfo info = FileVersionInfo.GetVersionInfo(executablePath);
-                    version = info.FileVersion != null ? (info.FileVersion.Split(".")[0] + "." + info.FileVersion.Split(".")[1]) : version;
-                }
-                catch (FileNotFoundException ex)
-                {
-                    Logger.Warn($"Executable not found at '{executablePath}': {ex.Message}");
-                }
-            # endif
-            // TODO: Is there a way we can somehow get the version automatically on linux?
-
-            Installations.Add(new Installation
-            {
-                Type = type,
-                Path = gamePath,
-                DocumentsPath = documentsPath,
-                ExecutablePath = executablePath,
-                Version = version
-            });
-
-            Installation installation = Installations[^1];
+            CreateInstallation(type, gamePath, isManual: false);
         }
+
+        foreach (string gamePath in GameSettings.Current.ManualGamePaths)
+        {
+            GameType? type = DetectGameType(gamePath);
+            if (type == null)
+            {
+                Logger.Warn($"Manually added game at '{gamePath}' no longer contains a game executable, skipping.");
+                continue;
+            }
+
+            CreateInstallation(type.Value, gamePath, isManual: true);
+        }
+    }
+
+    private static string GetExecutablePath(string gamePath, GameType type)
+    {
+        return Path.Combine(
+            # if WINDOWS
+                gamePath,
+                "bin",
+                "win_x64",
+                type == GameType.EuroTruckSimulator2 ? "eurotrucks2.exe"
+                                                     : "amtrucks.exe"
+            # else
+                gamePath,
+                "bin",
+                "linux_x64",
+                type == GameType.EuroTruckSimulator2 ? "eurotrucks2"
+                                                     : "amtrucks"
+            # endif
+        );
+    }
+
+    /// <summary>Checks which game executable exists in the folder, null if neither.</summary>
+    public static GameType? DetectGameType(string gamePath)
+    {
+        if (File.Exists(GetExecutablePath(gamePath, GameType.EuroTruckSimulator2)))
+            return GameType.EuroTruckSimulator2;
+        if (File.Exists(GetExecutablePath(gamePath, GameType.AmericanTruckSimulator)))
+            return GameType.AmericanTruckSimulator;
+        return null;
+    }
+
+    /// <summary>Builds an installation for the folder and adds it to the list, skipping duplicates.</summary>
+    private Installation CreateInstallation(GameType type, string gamePath, bool isManual)
+    {
+        Installation? existing = Installations.FirstOrDefault(
+            i => Path.GetFullPath(i.Path) == Path.GetFullPath(gamePath));
+        if (existing != null)
+            return existing;
+
+        string executablePath = GetExecutablePath(gamePath, type);
+        string gameName = type == GameType.EuroTruckSimulator2 ? "Euro Truck Simulator 2"
+                                                               : "American Truck Simulator";
+        string documentsPath = Path.Combine(
+            #if WINDOWS
+                Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                gameName
+            #else
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".local", "share", gameName
+            #endif
+        );
+
+        string version = "Unknown";
+        # if WINDOWS
+            try
+            {
+                FileVersionInfo info = FileVersionInfo.GetVersionInfo(executablePath);
+                version = info.FileVersion != null ? (info.FileVersion.Split(".")[0] + "." + info.FileVersion.Split(".")[1]) : version;
+            }
+            catch (FileNotFoundException ex)
+            {
+                Logger.Warn($"Executable not found at '{executablePath}': {ex.Message}");
+            }
+        # endif
+
+        if (version == "Unknown")
+            version = GetVersionFromGameFiles(gamePath)
+                      ?? GetVersionFromLogs(documentsPath)
+                      ?? version;
+
+        Logger.Info($"Found {gameName} (version: {version}) at '{gamePath}'");
+
+        Installation installation = new Installation
+        {
+            Type = type,
+            Path = gamePath,
+            DocumentsPath = documentsPath,
+            ExecutablePath = executablePath,
+            Version = version,
+            IsManuallyAdded = isManual
+        };
+
+        Installations = new List<Installation>(Installations) { installation };
+        return installation;
+    }
+
+    /// <summary>Adds a game installation from a selected folder and remembers
+    /// it for future sessions. Returns null if the folder doesn't contain a game.</summary>
+    public Installation? AddManualInstallation(string gamePath)
+    {
+        gamePath = Path.TrimEndingDirectorySeparator(gamePath);
+
+        GameType? type = DetectGameType(gamePath);
+        if (type == null)
+        {
+            Logger.Warn($"No game executable found in '{gamePath}', not adding it as an installation.");
+            return null;
+        }
+
+        Installation installation = CreateInstallation(type.Value, gamePath, isManual: true);
+
+        if (installation.IsManuallyAdded && !GameSettings.Current.ManualGamePaths.Contains(gamePath))
+        {
+            GameSettings.Current.ManualGamePaths.Add(gamePath);
+            GameSettings.Current.Save();
+        }
+
+        return installation;
+    }
+
+    /// <summary>Removes a manually added installation and forgets it for future sessions.</summary>
+    public void RemoveManualInstallation(Installation installation)
+    {
+        if (!installation.IsManuallyAdded)
+            return;
+
+        Logger.Info($"Removing manually added installation at '{installation.Path}'");
+        Installations = Installations.Where(i => i != installation).ToList();
+
+        GameSettings.Current.ManualGamePaths.RemoveAll(
+            p => Path.GetFullPath(p) == Path.GetFullPath(installation.Path));
+        GameSettings.Current.Save();
+    }
+
+    /// <summary>Reads the game version from the version.scs archive.</summary>
+    private static string? GetVersionFromGameFiles(string gamePath)
+    {
+        string versionScs = Path.Combine(gamePath, "version.scs");
+        if (!File.Exists(versionScs))
+            return null;
+
+        try
+        {
+            using var reader = HashFsReader.Open(versionScs);
+            if (reader.EntryExists("/version.sii") != EntryType.File)
+                return null;
+
+            string content = Encoding.UTF8.GetString(reader.Extract("/version.sii")[0]);
+            Match match = Regex.Match(content, "version:\\s*\"(\\d+\\.\\d+)");
+            return match.Success ? match.Groups[1].Value : null;
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Failed to read version from '{versionScs}': {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>Reads the game version from the game's log file.
+    /// Only works if the game has been run at least once.</summary>
+    private static string? GetVersionFromLogs(string documentsPath)
+    {
+        string logFile = Path.Combine(documentsPath, "game.log.txt");
+        if (!File.Exists(logFile))
+            return null;
+
+        try
+        {
+            // The game holds the log file open, so allow shared access.
+            using var stream = new FileStream(logFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(stream);
+
+            string? line;
+            int linesRead = 0;
+            while ((line = reader.ReadLine()) != null && linesRead++ < 2000)
+            {
+                Match match = Regex.Match(line, "init ver\\.(\\d+\\.\\d+)");
+                if (match.Success)
+                    return match.Groups[1].Value;
+            }
+        }
+        catch (IOException ex)
+        {
+            Logger.Warn($"Failed to read version from '{logFile}': {ex.Message}");
+        }
+
+        return null;
     }
 }

--- a/ETS2LA.Game/Settings.cs
+++ b/ETS2LA.Game/Settings.cs
@@ -1,0 +1,36 @@
+using ETS2LA.Settings;
+
+namespace ETS2LA.Game;
+
+[Serializable]
+public class GameSettings
+{
+    public List<string> ManualGamePaths { get; set; } = new();
+
+    [NonSerialized]
+    private static readonly Lazy<GameSettings> _instance = new(() => new GameSettings(loadSettings: true));
+    public static GameSettings Current => _instance.Value;
+
+    [NonSerialized]
+    private SettingsHandler? _settingsHandler;
+
+    public GameSettings(bool loadSettings = false)
+    {
+        if (loadSettings)
+        {
+            _settingsHandler = new SettingsHandler();
+            var loadedSettings = _settingsHandler.Load<GameSettings>("GameSettings.json");
+            if (loadedSettings != null)
+            {
+                ManualGamePaths = loadedSettings.ManualGamePaths;
+            }
+        }
+    }
+
+    public GameSettings() { }
+
+    public void Save()
+    {
+        _settingsHandler?.Save<GameSettings>("GameSettings.json", this);
+    }
+}

--- a/ETS2LA.UI/Views/Settings/SDKSettings.axaml
+++ b/ETS2LA.UI/Views/Settings/SDKSettings.axaml
@@ -62,8 +62,8 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
 
-            <TextBlock Text="Game missing? If your installation wasn't detected automatically, you can add it by selecting its install folder (the one containing base.scs)." Classes="Description" Margin="14 7 14 0" TextWrapping="Wrap" />
-            <Button Content="Add Game Manually" Width="150" HorizontalAlignment="Left" Margin="14 7 14 7" Click="OnAddGameManually" AutomationProperties.Name="Add Game Manually" />
+            <TextBlock Text="Game missing? You can add it by selecting its install folder. If you see 'bin' and 'licenses' you're in the right place." Classes="Description" Margin="14 7 14 7" TextWrapping="Wrap" />
+            <Button Content="Add Game Manually" Width="160" HorizontalAlignment="Left" Margin="14 7 14 7" Click="OnAddGameManually" AutomationProperties.Name="Add Game Manually" />
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/ETS2LA.UI/Views/Settings/SDKSettings.axaml
+++ b/ETS2LA.UI/Views/Settings/SDKSettings.axaml
@@ -13,8 +13,6 @@
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel>
             <TextBlock Text="Click a card to install/uninstall our SDKs." Classes="Description" Margin="14 7 14 7" />
-            <TextBlock Text="Note: On linux we cannot automatically detect the game version, please enter it manually." Margin="14 7 14 7" IsVisible="{Binding IsLinux}" />
-            <TextBlock Text="We also cannot automatically detect if the SDK is installed. Update work as expected, but for uninstalling you need to do it manually." Margin="14 7 14 7" IsVisible="{Binding IsLinux}" />
             <ItemsControl x:Name="GameList" ItemsSource="{Binding Games}" ItemsPanel="{StaticResource WrapPanelTemplate}" AutomationProperties.Name="List of detected games">
 
                 <ItemsControl.Styles>
@@ -42,7 +40,7 @@
                             AutomationProperties.Name="{Binding AutomationName}"
                             AutomationProperties.AccessibilityView="Content"
                         >
-                            <Grid ColumnDefinitions="*, Auto" ColumnSpacing="6">
+                            <Grid ColumnDefinitions="*, Auto, Auto" ColumnSpacing="6">
                                 <StackPanel Spacing="6" Grid.Column="0">
                                     <StackPanel Spacing="6" Orientation="Horizontal">
                                         <husk:Tag Grid.Column="1" IsVisible="{Binding IsSDKInstalled}" Classes="Primary" HorizontalAlignment="Right">
@@ -57,11 +55,15 @@
                                     <TextBlock Text="{Binding Path}" Classes="Description" FontSize="12" Padding="0 0 0 4" />
                                 </StackPanel>
                                 <TextBox Grid.Column="1" PlaceholderText="Enter Version" IsVisible="{Binding IsUnknownVersion}" Text="{Binding UpdatedVersion, Mode=TwoWay}" FontSize="12" Width="200" HorizontalAlignment="Right" />
+                                <Button Grid.Column="2" Content="Remove" FontSize="12" IsVisible="{Binding IsManuallyAdded}" Tag="{Binding}" Click="OnRemoveGame" VerticalAlignment="Center" AutomationProperties.Name="{Binding Name, StringFormat='Remove manually added {0}'}" />
                             </Grid>
                         </husk:Card>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
+
+            <TextBlock Text="Game missing? If your installation wasn't detected automatically, you can add it by selecting its install folder (the one containing base.scs)." Classes="Description" Margin="14 7 14 0" TextWrapping="Wrap" />
+            <Button Content="Add Game Manually" Width="150" HorizontalAlignment="Left" Margin="14 7 14 7" Click="OnAddGameManually" AutomationProperties.Name="Add Game Manually" />
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/ETS2LA.UI/Views/Settings/SDKSettings.axaml.cs
+++ b/ETS2LA.UI/Views/Settings/SDKSettings.axaml.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using Avalonia.Interactivity;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Platform.Storage;
 
 using ETS2LA.Game;
 using ETS2LA.Notifications;
@@ -15,12 +16,6 @@ namespace ETS2LA.UI.Views.Settings;
 public partial class SDKSettings : UserControl
 {
     public ObservableCollection<GameItem> Games { get; } = new();
-
-    # if LINUX
-    public bool IsLinux => true;
-    # else
-    public bool IsLinux => false;
-    # endif
 
     public SDKSettings()
     {
@@ -59,6 +54,47 @@ public partial class SDKSettings : UserControl
             }
         }
     }
+
+    private async void OnAddGameManually(object? sender, RoutedEventArgs e)
+    {
+        var topLevel = TopLevel.GetTopLevel(this);
+        if (topLevel == null)
+            return;
+
+        var folders = await topLevel.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = "Select the game's install folder",
+            AllowMultiple = false
+        });
+
+        if (folders.Count == 0)
+            return;
+
+        string? gamePath = folders[0].TryGetLocalPath();
+        var installation = gamePath != null ? GameHandler.Current.AddManualInstallation(gamePath) : null;
+        if (installation == null)
+        {
+            NotificationHandler.Current.SendNotification(new Notification
+            {
+                Id = "ETS2LA.UI.SDKSettings.AddGameFailed",
+                Title = "Could not add game",
+                Content = "No ETS2 or ATS executable was found in the selected folder. Please select the game's install folder, for example '.../steamapps/common/Euro Truck Simulator 2'.",
+                Level = NotificationLevel.Danger
+            });
+            return;
+        }
+
+        UpdateGamesList();
+    }
+
+    private void OnRemoveGame(object? sender, RoutedEventArgs e)
+    {
+        if (sender is Control { Tag: GameItem item })
+        {
+            GameHandler.Current.RemoveManualInstallation(item.Installation);
+            UpdateGamesList();
+        }
+    }
 }
 
 public class GameItem : INotifyPropertyChanged
@@ -69,8 +105,11 @@ public class GameItem : INotifyPropertyChanged
     public string Path => installation.Path;
     public bool IsUnknownVersion => !Version.Contains(".");
     public bool IsSDKInstalled => installation.IsSDKInstalled(IsUnknownVersion ? UpdatedVersion : Version);
+    public bool IsManuallyAdded => installation.IsManuallyAdded;
 
     public string AutomationName => GetAutomationName();
+
+    public Installation Installation => installation;
 
     private Installation installation;
 


### PR DESCRIPTION
Tested on Fedora it worked for me with no issues.
I made it check the version from ```version.scs``` with trucklib, the fallback is ```game.log.txt```.

Also IF it happens to not find the game i added a button so the game folder can be picked.

You are more experienced in UI design than me so please make sure to change it if you don't like it or there is a better way to do this :+1: 

This is how it looks like: 
<img width="1281" height="720" alt="Screenshot From 2026-07-10 14-24-58" src="https://github.com/user-attachments/assets/7bdfd03a-8009-4032-a431-397da6baef75" />

Also i didn't test on Windows, not planning to get back on it and i don't have any device that has it xd
But it should be fine tho