### PR TITLE
Fix false crash on exit from IBus DBus exception on Linux

### DIFF
--- a/ETS2LA/Program.cs
+++ b/ETS2LA/Program.cs
@@ -39,6 +39,15 @@ internal static class Program
         TaskScheduler.UnobservedTaskException += (sender, e) =>
         {
             e.SetObserved(); // Prevents an immediate crash, we'll handle termination in HandleFatalException instead.
+
+            // Avalonia's IBus integration on linux throws these from DBus calls
+            // that nothing awaits (like when closing the window). They are harmless, can be ignored.
+            if (e.Exception.Flatten().InnerExceptions.All(ex => ex is Tmds.DBus.Protocol.DBusExceptionBase))
+            {
+                Logger.Warn($"Ignored DBus exception: {e.Exception.InnerException?.Message}");
+                return;
+            }
+
             HandleFatalException(e.Exception);
         };
 
@@ -143,6 +152,9 @@ internal static class Program
     private static void HandleFatalException(Exception? ex)
     {
         if (ex == null) return;
+
+        if (ex is AggregateException aggregate)
+            ex = aggregate.Flatten().InnerExceptions.FirstOrDefault() ?? ex;
 
         string errorMessage = $"ETS2LA has encountered a fatal error.\n\n" +
                               $"Error: {ex.Message}\n\n" +


### PR DESCRIPTION
Got an IBus exception message every time i closed the ETS2LA window: 
<img width="435" height="434" alt="Screenshot From 2026-07-10 15-29-26" src="https://github.com/user-attachments/assets/043a08dc-ee1e-465d-8481-fbbf8f4bfe88" />

This is Avalonia's fault tho, this only happened on linux bc of the integration.
Made it so it logs the DBus exceptions but ignore them since this was just a harmless pop-up.
And also made it so that actual crashes not like this one show the stack trace.