### PR TITLE
Fix Spectre markup leaking into overlay console and log file

### DIFF
--- a/ETS2LA.Logging/Program.cs
+++ b/ETS2LA.Logging/Program.cs
@@ -63,8 +63,17 @@ public static class Logger
         Exception ex = null
     )
     {
-        message = Markup.Escape(message);
-        OnLog?.Invoke(Tuple.Create(level, message));
+        // overlay + log file want plain text
+        string plainMessage;
+        try
+        {
+            plainMessage = Markup.Remove(message);
+        }
+        catch
+        {
+            plainMessage = message;
+        }
+        OnLog?.Invoke(Tuple.Create(level, plainMessage));
         var source = GetSourceInfo(filePath, lineNumber);
         var timestamp = GetTimestamp();
         var levelTag = $"[{color}][[{level}]][/]";
@@ -85,7 +94,7 @@ public static class Logger
         {
             // If something goes wrong with the markup (eg. message contains invalid markup)
             // just print the message without markup instead of crashing the logger.
-            Console.WriteLine($"{timestamp} [{level}] {message} ({source})");
+            Console.WriteLine($"{timestamp} [{level}] {plainMessage} ({source})");
             Console.WriteLine($"Error while writing log line: {markupEx}");
             return;
         }


### PR DESCRIPTION
Was causing this and my brain didn't like it:
<img width="1313" height="52" alt="Screenshot From 2026-07-12 18-21-08" src="https://github.com/user-attachments/assets/1163a98d-59d7-4937-9ae3-3cc7e0ddd025" />

Cleaned now :+1: 