### PR TITLE
Fix catalogue restart

### DIFF
--- a/ETS2LA.UI/Views/CatalogueView.axaml.cs
+++ b/ETS2LA.UI/Views/CatalogueView.axaml.cs
@@ -52,11 +52,15 @@ public partial class CatalogueView : UserControl, INotifyPropertyChanged
     private void OnRestartClick(object? sender, RoutedEventArgs e)
     {
         Logger.Info("Restarting ETS2LA...");
-        Process.Start(new ProcessStartInfo
+        using Process currentProcess = Process.GetCurrentProcess();
+        var startInfo = new ProcessStartInfo
         {
-            FileName = System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName,
+            FileName = currentProcess.MainModule?.FileName,
             UseShellExecute = true
-        });
+        };
+        // Let the new instance wait for this process to exit.
+        startInfo.ArgumentList.Add($"--restart-parent-process-id={currentProcess.Id}");
+        Process.Start(startInfo);
         Environment.Exit(0);
     }
 

--- a/ETS2LA/Program.cs
+++ b/ETS2LA/Program.cs
@@ -52,6 +52,8 @@ internal static class Program
             Utils.HandleFatalException(e.Exception, tracerProvider, meterProvider);
         };
 
+        args = Utils.WaitForRestartParentProcess(args);
+
         if (Utils.DoesETS2LAProcessExist())
             throw new InvalidOperationException("ETS2LA is already running, please close it from the Task Manager.");
 

--- a/ETS2LA/Utils.cs
+++ b/ETS2LA/Utils.cs
@@ -66,6 +66,31 @@ static class Utils
         var processes = System.Diagnostics.Process.GetProcessesByName(processName);
         return processes.Length > 1;
     }
+
+    public static string[] WaitForRestartParentProcess(string[] args)
+    {
+        const string argumentPrefix = "--restart-parent-process-id=";
+        string? restartArgument = args.FirstOrDefault(argument => argument.StartsWith(argumentPrefix, StringComparison.Ordinal));
+
+        if (restartArgument == null)
+            return args;
+
+        string processIdValue = restartArgument[argumentPrefix.Length..];
+        if (int.TryParse(processIdValue, out int processId) && processId != Environment.ProcessId)
+        {
+            try
+            {
+                // Avoid triggering the single-instance check during a restart.
+                using var process = System.Diagnostics.Process.GetProcessById(processId);
+                process.WaitForExit();
+            }
+            catch (ArgumentException) { }
+            catch (InvalidOperationException) { }
+        }
+
+        // Keep the internal restart argument away from the UI.
+        return args.Where(argument => !argument.StartsWith(argumentPrefix, StringComparison.Ordinal)).ToArray();
+    }
 }
 
 internal static class NativeMethods


### PR DESCRIPTION
Caused the "crash" because the catalouge restart started a new process before closing the old one, and if it starts too quickly it sees the 2 processes and throws the error. 
Didnt affect everyone tho, only those with fast PCs (thats why this didnt happen to me xd)

Also havent tested on windows yet but should be fine