### PR TITLE
Add OpenCataloguePage Button, add NavigateToPage, etc

### DIFF
--- a/ETS2LA.UI/MainWindow.axaml.cs
+++ b/ETS2LA.UI/MainWindow.axaml.cs
@@ -17,7 +17,6 @@ using Huskui.Avalonia.Controls;
 namespace ETS2LA.UI;
 
 // TODO: Documentation, cleanup code!
-
 public partial class MainWindow : AppWindow
 {
     public static MainWindow? Instance { get; private set; }

--- a/ETS2LA.UI/MainWindow.axaml.cs
+++ b/ETS2LA.UI/MainWindow.axaml.cs
@@ -1,4 +1,3 @@
-
 using Avalonia.Media;
 using Avalonia.Input;
 using Avalonia.Controls;
@@ -20,6 +19,7 @@ namespace ETS2LA.UI;
 public partial class MainWindow : AppWindow
 {
     public static MainWindow? Instance { get; private set; }
+    
     public enum PageKind
     {
         Dashboard,

--- a/ETS2LA.UI/MainWindow.axaml.cs
+++ b/ETS2LA.UI/MainWindow.axaml.cs
@@ -1,3 +1,4 @@
+
 using Avalonia.Media;
 using Avalonia.Input;
 using Avalonia.Controls;
@@ -16,9 +17,11 @@ using Huskui.Avalonia.Controls;
 namespace ETS2LA.UI;
 
 // TODO: Documentation, cleanup code!
+
 public partial class MainWindow : AppWindow
 {
-    private enum PageKind
+    public static MainWindow? Instance { get; private set; }
+    public enum PageKind
     {
         Dashboard,
         Visualization,
@@ -41,6 +44,7 @@ public partial class MainWindow : AppWindow
 
     public MainWindow()
     {
+        Instance = this;
         CanResize = true;
         ExtendClientAreaToDecorationsHint = true;
         InitializeComponent();
@@ -293,5 +297,44 @@ public partial class MainWindow : AppWindow
     {
         SetSelected(SettingsButton);
         ShowPage(PageKind.Settings);
+    }
+    public void NavigateToPage( PageKind page)
+    {
+        switch (page)
+        {
+            case PageKind.Dashboard:
+                ShowPage(PageKind.Dashboard);
+                SetSelected(DashboardButton);
+                break;
+            case PageKind.Visualization:
+                ShowPage(PageKind.Visualization);
+                SetSelected(VisualizationButton);
+                break;
+            case PageKind.Manager:
+                ShowPage(PageKind.Manager);
+                SetSelected(ManagerButton);
+                break;
+            case PageKind.Catalogue:
+                ShowPage(PageKind.Catalogue);
+                SetSelected(CatalogueButton);
+                break;
+            case PageKind.Performance:
+                ShowPage(PageKind.Performance);
+                SetSelected(PerformanceButton);
+                break;
+            case PageKind.Wiki:
+                ShowPage(PageKind.Wiki);
+                SetSelected(WikiButton);
+                break;
+            case PageKind.Roadmap:
+                ShowPage(PageKind.Roadmap);
+                SetSelected(RoadmapButton);
+                break;
+            case PageKind.Settings:
+                ShowPage(PageKind.Settings);
+                SetSelected(SettingsButton);
+                break;
+        }
+
     }
 }

--- a/ETS2LA.UI/MainWindow.axaml.cs
+++ b/ETS2LA.UI/MainWindow.axaml.cs
@@ -298,6 +298,7 @@ public partial class MainWindow : AppWindow
         SetSelected(SettingsButton);
         ShowPage(PageKind.Settings);
     }
+    
     public void NavigateToPage( PageKind page)
     {
         switch (page)

--- a/ETS2LA.UI/MainWindow.axaml.cs
+++ b/ETS2LA.UI/MainWindow.axaml.cs
@@ -298,7 +298,7 @@ public partial class MainWindow : AppWindow
         SetSelected(SettingsButton);
         ShowPage(PageKind.Settings);
     }
-    
+
     public void NavigateToPage( PageKind page)
     {
         switch (page)
@@ -336,6 +336,5 @@ public partial class MainWindow : AppWindow
                 SetSelected(SettingsButton);
                 break;
         }
-
     }
 }

--- a/ETS2LA.UI/Views/ManagerView.axaml
+++ b/ETS2LA.UI/Views/ManagerView.axaml
@@ -100,7 +100,10 @@
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
                 <StackPanel Margin="10" IsVisible="{Binding !HasPlugins}">
-                    <TextBlock Text="No plugins found, please make sure there are .DLLs in the plugins folder." Classes="Description" />
+                    <TextBlock Text="No plugins found, please make sure there are .DLLs in the plugins folder, or install via the Catalogue." Classes="Description" />
+                <WrapPanel Grid.Row="1" Margin="5">
+                    <Button Click="OpenCataloguePage" Content="Go to Catalogue" Classes="Primary" AutomationProperties.Name="Open Plugin Catalogue, button"/>
+                </WrapPanel>
                 </StackPanel>
             </StackPanel>
         </ScrollViewer>

--- a/ETS2LA.UI/Views/ManagerView.axaml
+++ b/ETS2LA.UI/Views/ManagerView.axaml
@@ -101,9 +101,9 @@
                 </ItemsControl>
                 <StackPanel Margin="10" IsVisible="{Binding !HasPlugins}">
                     <TextBlock Text="No plugins found, please make sure there are .DLLs in the plugins folder, or install via the Catalogue." Classes="Description" />
-                <WrapPanel Grid.Row="1" Margin="0,12,0,0">
-                    <Button Click="OpenCataloguePage" Content="Go to Catalogue" Classes="Secondary" AutomationProperties.Name="Open Plugin Catalogue, button"/>
-                </WrapPanel>
+                    <WrapPanel Grid.Row="1" Margin="0,12,0,0">
+                        <Button Click="OpenCataloguePage" Content="Go to Catalogue" Classes="Secondary" AutomationProperties.Name="Open Plugin Catalogue, button"/>
+                    </WrapPanel>
                 </StackPanel>
             </StackPanel>
         </ScrollViewer>

--- a/ETS2LA.UI/Views/ManagerView.axaml
+++ b/ETS2LA.UI/Views/ManagerView.axaml
@@ -101,8 +101,8 @@
                 </ItemsControl>
                 <StackPanel Margin="10" IsVisible="{Binding !HasPlugins}">
                     <TextBlock Text="No plugins found, please make sure there are .DLLs in the plugins folder, or install via the Catalogue." Classes="Description" />
-                <WrapPanel Grid.Row="1" Margin="5">
-                    <Button Click="OpenCataloguePage" Content="Go to Catalogue" Classes="Primary" AutomationProperties.Name="Open Plugin Catalogue, button"/>
+                <WrapPanel Grid.Row="1" Margin="0,8,0,0">
+                    <Button Click="OpenCataloguePage" Content="Go to Catalogue" Classes="Secondary" AutomationProperties.Name="Open Plugin Catalogue, button"/>
                 </WrapPanel>
                 </StackPanel>
             </StackPanel>

--- a/ETS2LA.UI/Views/ManagerView.axaml
+++ b/ETS2LA.UI/Views/ManagerView.axaml
@@ -101,7 +101,7 @@
                 </ItemsControl>
                 <StackPanel Margin="10" IsVisible="{Binding !HasPlugins}">
                     <TextBlock Text="No plugins found, please make sure there are .DLLs in the plugins folder, or install via the Catalogue." Classes="Description" />
-                <WrapPanel Grid.Row="1" Margin="0,8,0,0">
+                <WrapPanel Grid.Row="1" Margin="0,12,0,0">
                     <Button Click="OpenCataloguePage" Content="Go to Catalogue" Classes="Secondary" AutomationProperties.Name="Open Plugin Catalogue, button"/>
                 </WrapPanel>
                 </StackPanel>

--- a/ETS2LA.UI/Views/ManagerView.axaml.cs
+++ b/ETS2LA.UI/Views/ManagerView.axaml.cs
@@ -15,6 +15,15 @@ namespace ETS2LA.UI.Views;
 
 public partial class ManagerView : UserControl, INotifyPropertyChanged
 {
+    
+    private void OpenCataloguePage(object? sender, RoutedEventArgs e)
+    {
+        var mainWindow = MainWindow.Instance;
+        if (mainWindow != null)
+        {
+            mainWindow.NavigateToPage(MainWindow.PageKind.Catalogue);
+        }
+    }
     // This list is listened by the UI to show available plugins.
     public ObservableCollection<PluginItem> Plugins { get; } = new();
     public ObservableCollection<PluginItem> FilteredPlugins { get; } = new();

--- a/ETS2LA.UI/Views/ManagerView.axaml.cs
+++ b/ETS2LA.UI/Views/ManagerView.axaml.cs
@@ -15,14 +15,6 @@ namespace ETS2LA.UI.Views;
 
 public partial class ManagerView : UserControl, INotifyPropertyChanged
 {  
-    private void OpenCataloguePage(object? sender, RoutedEventArgs e)
-    {
-        var mainWindow = MainWindow.Instance;
-        if (mainWindow != null)
-        {
-            mainWindow.NavigateToPage(MainWindow.PageKind.Catalogue);
-        }
-    }
     // This list is listened by the UI to show available plugins.
     public ObservableCollection<PluginItem> Plugins { get; } = new();
     public ObservableCollection<PluginItem> FilteredPlugins { get; } = new();
@@ -158,6 +150,15 @@ public partial class ManagerView : UserControl, INotifyPropertyChanged
         # else
         Process.Start("open", location);
         #endif
+    }
+
+    private void OpenCataloguePage(object? sender, RoutedEventArgs e)
+    {
+        var mainWindow = MainWindow.Instance;
+        if (mainWindow != null)
+        {
+            mainWindow.NavigateToPage(MainWindow.PageKind.Catalogue);
+        }
     }
 
     private void InitializeComponent()

--- a/ETS2LA.UI/Views/ManagerView.axaml.cs
+++ b/ETS2LA.UI/Views/ManagerView.axaml.cs
@@ -14,8 +14,7 @@ using ETS2LA.Logging;
 namespace ETS2LA.UI.Views;
 
 public partial class ManagerView : UserControl, INotifyPropertyChanged
-{
-    
+{  
     private void OpenCataloguePage(object? sender, RoutedEventArgs e)
     {
         var mainWindow = MainWindow.Instance;


### PR DESCRIPTION
# Description
This adds OpenCataloguePage Button to the Manager when no plugins are installed, adds NavigateToPage to MainWindow for any resource to Navigate to a page easily.
This also makes PageKind a public enum aswell, in order to be able to change the page. 
Files Changed: ManagerView.axaml.cs,
ManagerView.axaml, MainWindow.axaml.cs. 

# Type of change
Check the relevant options (place an "x" between the brackets)

[x] - New Feature