### PR TITLE
Fix overlay frame pacer never recovering from a missed deadline

### DIFF
--- a/ETS2LA.Overlay/Overlay.cs
+++ b/ETS2LA.Overlay/Overlay.cs
@@ -126,6 +126,8 @@ public class OverlayHandler
                 interval = 1000.0 / targetFramerate;
 
             start = fs.Elapsed.TotalMilliseconds;
+            if (next < start)
+                next = start;
             next += interval;
 
             if (!isInteracting) { 


### PR DESCRIPTION
It would never reach schedule again before and just maxes a cpu core forever
So we just let it catch up