### PR TITLE
Fix plugin version order

### DIFF
--- a/ETS2LA.Networking/Plugins/classes.cs
+++ b/ETS2LA.Networking/Plugins/classes.cs
@@ -48,7 +48,7 @@ public class NetworkPlugin
         var compatibleVersions = Versions
             .Where(v => IsCompatible(Version.Parse(appVersion), v.AppVersion))
             .Where(v => v.SupportedOperatingSystems.Contains(os))
-            .OrderByDescending(v => v.Version)
+            .OrderByDescending(v => Version.TryParse(v.Version, out var parsed) ? parsed : new Version(0, 0, 0))
             .ToList();
         return compatibleVersions.FirstOrDefault();
     }


### PR DESCRIPTION
- Fixes plugin versions being sorted as strings because `3.9.0` was shown as above `3.10.0`
- Fixes the update loop (Permanent "Update available") shown

Im gonna write the changes from now like this too if thats okay with you, i think its easier to understand than me writing an essay on the changes :D