### PR TITLE
Fix GetBestLane stack overflow

### DIFF
--- a/ETS2LA.Game/Data/Classes.cs
+++ b/ETS2LA.Game/Data/Classes.cs
@@ -283,7 +283,7 @@ public class ParsedRoad : IParsedItem
             }
         }
 
-        if (closestLaneDistance > 4.5f * 3) // 3 lanes
+        if (!inverted && closestLaneDistance > 4.5f * 3) // 3 lanes
             closestLane = GetBestLaneFor(Position, true);
 
         return closestLane;
@@ -698,7 +698,7 @@ public class ParsedRoadList : IParsedItem
             }
         }
 
-        if (closestLaneDistance > 4.5f * 3) // 3 lanes
+        if (!inverted && closestLaneDistance > 4.5f * 3) // 3 lanes
             closestLane = GetBestLaneFor(Position, true);
 
         return closestLane;

--- a/ETS2LA.Game/Data/Classes.cs
+++ b/ETS2LA.Game/Data/Classes.cs
@@ -255,7 +255,7 @@ public class ParsedRoad : IParsedItem
     /// </summary>
     /// <param name="Position">The input position to check.</param>
     /// <returns>The best lane for the given position.</returns>
-    public int GetBestLaneFor(Vector3 Position, bool inverted = false)
+    public int GetBestLaneFor(Vector3 Position, bool inverted = false, bool allowRetry = true)
     {
         float closestFactor = GetFactorForPoint(Position);
         if (inverted) closestFactor = 1 - closestFactor;
@@ -283,8 +283,8 @@ public class ParsedRoad : IParsedItem
             }
         }
 
-        if (!inverted && closestLaneDistance > 4.5f * 3) // 3 lanes
-            closestLane = GetBestLaneFor(Position, true);
+        if (allowRetry && closestLaneDistance > 4.5f * 3) // 3 lanes
+            closestLane = GetBestLaneFor(Position, !inverted, false);
 
         return closestLane;
     }
@@ -670,7 +670,7 @@ public class ParsedRoadList : IParsedItem
     /// </summary>
     /// <param name="Position">The input position to check.</param>
     /// <returns>The best lane for the given position.</returns>
-    public int GetBestLaneFor(Vector3 Position, bool inverted = false)
+    public int GetBestLaneFor(Vector3 Position, bool inverted = false, bool allowRetry = true)
     {
         float closestFactor = GetFactorForPoint(Position);
         if (inverted) closestFactor = 1 - closestFactor;
@@ -698,8 +698,8 @@ public class ParsedRoadList : IParsedItem
             }
         }
 
-        if (!inverted && closestLaneDistance > 4.5f * 3) // 3 lanes
-            closestLane = GetBestLaneFor(Position, true);
+        if (allowRetry && closestLaneDistance > 4.5f * 3) // 3 lanes
+            closestLane = GetBestLaneFor(Position, !inverted, false);
 
         return closestLane;
     }


### PR DESCRIPTION
Limit the GetBestLaneFor fallback to a single retry, it previously recursed forever and crashed ETS2LA with a stack overflow.

Thats the best guess i have right now because i couldnt reproduce it myself, but seems pretty obvious to me it was this one, from the logs too (correct me if im wrong).