### PR TITLE
Fix/road interpolation and ar projection

### DIFF
--- a/ETS2LA.Game/Data/Classes.cs
+++ b/ETS2LA.Game/Data/Classes.cs
@@ -1213,7 +1213,6 @@ public class ParsedPrefab : IParsedItem
     public PrefabDescriptor? Descriptor;
 
     private Vector3 prefabStart;
-    private Vector3 prefabRotation;
     Matrix4x4 rotationMatrix;
 
     public ParsedPrefab(Prefab prefab)
@@ -1222,10 +1221,15 @@ public class ParsedPrefab : IParsedItem
         Descriptor = (PrefabDescriptor?)PpdFileHandler.Current.GetPpdFile(prefab.Model.ToString());
 
         prefabStart = prefab.Nodes[0].Position - Descriptor.Nodes[prefab.Origin].Position;
-        prefabRotation = prefab.Nodes[0].Rotation.ToEuler() - MathEx.GetNodeRotation(Descriptor.Nodes[prefab.Origin].Direction).ToEuler();
-        rotationMatrix = Matrix4x4.CreateRotationY(prefabRotation.Y, prefab.Nodes[0].Position);
-        rotationMatrix *= Matrix4x4.CreateRotationX(-prefabRotation.X, prefab.Nodes[0].Position);
-        rotationMatrix *= Matrix4x4.CreateRotationZ(prefabRotation.Z, prefab.Nodes[0].Position);
+
+        // Euler triples dont subtract, that only held while both rotations were pure yaw
+        Quaternion descriptorRotation = MathEx.GetNodeRotation(Descriptor.Nodes[prefab.Origin].Direction);
+        Quaternion relativeRotation = Quaternion.Normalize(prefab.Nodes[0].Rotation * Quaternion.Conjugate(descriptorRotation));
+
+        Vector3 pivot = prefab.Nodes[0].Position;
+        rotationMatrix = Matrix4x4.CreateTranslation(-pivot)
+                       * Matrix4x4.CreateFromQuaternion(relativeRotation)
+                       * Matrix4x4.CreateTranslation(pivot);
     }
 
     public ControlNode GetControlNodeForNode(Node node)

--- a/ETS2LA.Game/Data/Classes.cs
+++ b/ETS2LA.Game/Data/Classes.cs
@@ -663,7 +663,10 @@ public class ParsedRoadList : IParsedItem
             if (accumulatedLength + r.Road.Length >= distance - 1f)
             {
                 float localDistance = distance - accumulatedLength;
-                float localFactor = localDistance / r.Road.Length;
+
+                // The road above can end up to a metre before the distance we asked for, so
+                // this can come out above 1 and InterpolateCurve would extrapolate the curve.
+                float localFactor = Math.Clamp(localDistance / r.Road.Length, 0f, 1f);
                 return localFactor;
             }
             accumulatedLength += r.Road.Length;

--- a/ETS2LA.Game/Data/Classes.cs
+++ b/ETS2LA.Game/Data/Classes.cs
@@ -1224,7 +1224,7 @@ public class ParsedPrefab : IParsedItem
         prefabStart = prefab.Nodes[0].Position - Descriptor.Nodes[prefab.Origin].Position;
         prefabRotation = prefab.Nodes[0].Rotation.ToEuler() - MathEx.GetNodeRotation(Descriptor.Nodes[prefab.Origin].Direction).ToEuler();
         rotationMatrix = Matrix4x4.CreateRotationY(prefabRotation.Y, prefab.Nodes[0].Position);
-        rotationMatrix *= Matrix4x4.CreateRotationX(prefabRotation.X, prefab.Nodes[0].Position);
+        rotationMatrix *= Matrix4x4.CreateRotationX(-prefabRotation.X, prefab.Nodes[0].Position);
         rotationMatrix *= Matrix4x4.CreateRotationZ(prefabRotation.Z, prefab.Nodes[0].Position);
     }
 

--- a/ETS2LA.Overlay/AR/AR.cs
+++ b/ETS2LA.Overlay/AR/AR.cs
@@ -184,6 +184,10 @@ public class ARRenderer
         return thisFrameProjection;
     }
 
+    // Closer than this the perspective divide throws the point way outside -1 to 1 instead
+    // of behind us, which stretches anything drawn from several points across the screen.
+    private const float NearClipDistance = 1.0f;
+
     /// <summary>
     ///  Convert a world position into a screen coordinate. This takes all current
     ///  camera variables into account.
@@ -198,7 +202,7 @@ public class ARRenderer
             thisFrameViewProjection = GetViewMatrix() * GetProjectionMatrix();
 
         Vector4 clipSpacePos = Vector4.Transform(new Vector4(worldPos, 1.0f), thisFrameViewProjection);
-        if (clipSpacePos.W <= 0.1f) return null; // behind the camera
+        if (clipSpacePos.W <= NearClipDistance) return null; // behind or right on top of the camera
 
         // perspective divide to normalize coordinates
         // so that means x,y is -1 to 1 where 0,0 is the center
@@ -220,7 +224,7 @@ public class ARRenderer
             thisFrameViewProjection = GetViewMatrix() * GetProjectionMatrix();
 
         Vector4 clipSpacePos = Vector4.Transform(new Vector4(worldPos, 1.0f), thisFrameViewProjection);
-        if (clipSpacePos.W <= 0.1f) return null; // behind
+        if (clipSpacePos.W <= NearClipDistance) return null; // behind or right on top of the camera
 
         return new Vector2(clipSpacePos.X / clipSpacePos.W, clipSpacePos.Y / clipSpacePos.W);
     }

--- a/ETS2LA/ETS2LA.csproj
+++ b/ETS2LA/ETS2LA.csproj
@@ -8,7 +8,7 @@
 
     <Title>ETS2LA</Title>
     <Description>Self driving for ETS2 and ATS.</Description>
-    <Version>3.4.35</Version>
+    <Version>3.4.36</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
ETS2LA 3.4.36:
- Fix prefab pitch being applied in the wrong direction, prefab paths sat metres above the roads they meet
- Clamp the road factor converted from a road list factor so the curve isnt extrapolated past its end
- Skip projecting points almost on the camera, they stretched AR geometry across the screen